### PR TITLE
fix: self-host materials on the agentic_vbench_* HF datasets

### DIFF
--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/1.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/1.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/12.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/10.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/13.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/11.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/14.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/12.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/15.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/13.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/18.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/14.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/19.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/15.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/20.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/16.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/22.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/17.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/24.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/18.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/2.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/2.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/4.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/3.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/5.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/4.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/6.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/5.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/7.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/6.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/9.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/7.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/10.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/8.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_7/resolve/main/materials/11.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_assembly/resolve/main/materials/9.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/1.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/1.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/10.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/10.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/11.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/11.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/12.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/12.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/13.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/13.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/14.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/14.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/15.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/15.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/16.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/16.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/17.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/17.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/18.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/18.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/19.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/19.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/2.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/2.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/20.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/20.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/21.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/21.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/22.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/22.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5/resolve/main/materials/25.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/23.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5/resolve/main/materials/2.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/24.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5/resolve/main/materials/29.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/25.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5/resolve/main/materials/11.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/26.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5/resolve/main/materials/7.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/27.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5/resolve/main/materials/3.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/28.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task29/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task29/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5/resolve/main/materials/10.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/29.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/3.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/3.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task30/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task30/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5/resolve/main/materials/20.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/30.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task31/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task31/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5/resolve/main/materials/4.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/31.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/4.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/4.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/5.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/5.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/6.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/6.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/7.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/7.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/8.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/8.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/steps/solve/workdir/setup.sh
@@ -2,7 +2,7 @@
 # Pre-agent fetch: pulls the per-task materials zip into /workspace/materials/.
 set -euo pipefail
 
-MATERIALS_URL="https://huggingface.co/datasets/ameddserM/video_edit_bench_task_5_5/resolve/main/materials/9.zip"
+MATERIALS_URL="https://huggingface.co/datasets/ameddserM/agentic_vbench_sequencing/resolve/main/materials/9.zip"
 
 mkdir -p /workspace/materials /workspace/output /workspace/work
 


### PR DESCRIPTION
## Summary

The 18 assembly + 31 sequencing tasks' `setup.sh` files were curling materials from the upstream `ameddserM/video_edit_bench_task_{5, 5_5, 7}` datasets we'd forked. **`video_edit_bench_task_7` is gated** — anonymous workers got 401, and our Modal runs only succeeded because Harbor was forwarding the operator's local `HF_TOKEN` via `task.toml`'s `HF_TOKEN = \"${HF_TOKEN:-}\"`. Anyone cloning this repo without an HF account + access to the gated upstream couldn't run assembly at all.

Migrated all 49 materials zips onto the matching public `agentic_vbench_*` datasets so the workers fetch from the same dataset that holds the task metadata. Repair was already self-contained (codec-restore is the only Method-1 task; the other 19 still bake binaries — deferred).

## Per-family before / after

| Family | setup.sh used to curl from | Now curls from |
|---|---|---|
| `agentic_vbench_repair` | `ameddserM/agentic_vbench_repair` ✓ | unchanged |
| `agentic_vbench_assembly` | `ameddserM/video_edit_bench_task_7` (gated) | `ameddserM/agentic_vbench_assembly` (public) |
| `agentic_vbench_sequencing` | `ameddserM/video_edit_bench_task_5` + `_5_5` | `ameddserM/agentic_vbench_sequencing` (public) |

Each upstream `<source_id>.zip` was copied to `<new_task_id>.zip` to match the renumbered task IDs the dataset rows use.

## Verification

3 oracle smokes on Modal, all with `HF_TOKEN` explicitly **unset** to prove anonymous workers can fetch:

| Task | Reward |
|---|---:|
| `exp-codec-restore-task01` (repair, was already self-contained) | 1.0000 |
| `agentic-vbench-assembly-task1` | 1.0000 |
| `agentic-vbench-sequencing-task1` | 1.0000 |

## Files

49 modified `setup.sh` files (18 assembly + 31 sequencing). Only the `MATERIALS_URL=...` line changed; no other logic touched.

## Test plan

- [x] All 3 destination HF datasets verified public (no `gated`, no `private`)
- [x] New URLs return HTTP 302 without auth
- [x] Per-family oracle smoke at reward = 1.0 on Modal with HF_TOKEN unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)