### PR TITLE
fix: anchor repair verifier floors at ≤0.10 for broken passthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,9 @@ tasks/gopro-deblur-task*/steps/solve/workdir/blur/
 tasks/gopro-deblur-task*/steps/solve/tests/sharp/
 results/
 scripts/_internal/
+
+# Method-1 repair tasks: GT JSON files live in the HF materials zip and
+# are extracted by setup.sh at trial time, never checked in. Currently
+# only codec-restore-task01 is Method-1 — extend this list as the
+# remaining 18 Method-2 repair tasks are migrated.
+tasks/agentic_vbench_repair/exp-codec-restore-task*/steps/solve/tests/window.json

--- a/docs/VERIFIER_DESIGN.md
+++ b/docs/VERIFIER_DESIGN.md
@@ -17,7 +17,8 @@ receives) and the golden reference (the original, uncorrupted clip).
   `score = clip((M_broken − M_out) / (M_broken − M_golden), 0, 1)`
 
 By construction:
-- An agent that returns the broken input unmodified scores **0**.
+- An agent that returns the broken input unmodified scores at most the
+  preservation reservation (≤ 0.10 — see below).
 - The oracle solution (the bundled golden reference) scores **1**.
 - Any monotonic improvement on the chosen metric moves the score linearly
   between those anchors, clipped at the endpoints.
@@ -27,21 +28,48 @@ and DNS Challenge v3+.
 
 ## Per-family base metrics
 
-The metric for each family is chosen to maximise the broken→golden spread
-under the universal formula and to track the paper-canonical metric for
-that task type.
+The metric for each family tracks the paper-canonical metric for that
+task type and is mapped to `[0, 1]` with per-task LO/HI anchors picked
+so a broken passthrough lands at 0 and the golden identity lands at 1.
 
-| Family | Metric | Source |
+| Family | Restoration metric | Source |
 |---|---|---|
-| `dns-denoise`, `voicebank-denoise` | PESQ-WB in-window | DNS Challenge, Valentini 2016 |
-| `dereverb` | SRMR (no-reference) + PESQ-WB sanity gate | REVERB Challenge |
-| `declip` | Masked SI-SDR on `clip_mask` only | URGENT 2024 |
-| `codec-restore` | LSD in-window | Codec-SUPERB |
+| `dns-denoise` | DNSMOS-OVL + STOI + SI-SDR (PESQ-WB + STOI + SI-SDR fallback) | DNS Challenge 2020 |
+| `voicebank-denoise` | CSIG + CBAK + COVL composite | Valentini-Botinhao 2016 |
+| `dereverb` | PESQ-WB + STOI + CD | REVERB Challenge |
+| `declip` | Masked SI-SDR + ESTOI + PESQ-WB | URGENT 2024 |
+| `codec-restore` | DNSMOS-OVL + STOI + LSD_4-8kHz (PESQ-WB + LSD fallback) | Codec-SUPERB |
 | `color-shot` | CIEDE2000 in-window | CIE perceptual standard |
-| `deblur` | LPIPS (in-mask × in-window) | NTIRE perceptual track |
-| `sr` | 0.7·LPIPS + 0.3·Y-PSNR in-shot | NTIRE 2022+ composite |
-| `swap` | LPIPS on swap-window, ±5-frame tolerance | — |
+| `deblur` | PSNR-Y + SSIM-Y (in-mask × in-window) | NTIRE perceptual track |
+| `sr` | PSNR-Y + SSIM-Y in-shot + localisation IoU | NTIRE 2022+ composite |
+| `swap` | Whole-video PSNR + length penalty | — |
 | `cut`, `glitch`, `disfluency` | Binary range-F1 + SSIM honesty gate | — |
+
+## Preservation reservation
+
+Every video / audio judge with a localised corruption window also runs a
+preservation check on the untouched region (SSIM ≥ 0.95 outside the
+window). That check contributes **10% of the total reward**:
+
+```
+reward = 0.90 * restoration_score + 0.10 * preservation_pass
+```
+
+Why a reservation rather than a strict gate: a broken passthrough
+trivially passes preservation (it didn't change anything), so the 10%
+mass is technically free credit on the floor. We keep it as a
+reservation because it still meaningfully penalises agents that
+*degrade* the untouched region (SSIM < 0.95 → 0 there). A strict gate
+would collapse those to reward 0, which we found over-punishes
+near-miss agents.
+
+The honest range-F1 families (`cut`, `glitch`, `disfluency`) do not have
+a preservation reservation — their metric naturally floors at 0 for
+empty submissions and the SSIM gate catches honesty violations.
+
+`swap` also has no preservation reservation: the whole-video PSNR
+already drops sharply when the swapped shots aren't restored, so
+broken passthrough lands at 0 directly.
 
 ## Design choices
 
@@ -67,15 +95,15 @@ Each judge writes `/logs/verifier/reward.json`:
 {
   "reward": 0.412,
   "details": {
-    "metric_used": "pesq_wb",
-    "m_broken": 1.873,
-    "m_golden": 4.500,
-    "m_out":   2.957,
+    "reason": "ok",
+    "in_window": {"pesq_wb": 2.957, "stoi": 0.91, "...": "..."},
+    "out_window": {"out_si_sdr_db": 158.6, "out_n_samples": 320000},
+    "weights": {"in": 0.90, "out": 0.10},
     "...": "..."
   }
 }
 ```
 
-`reward` is the universal-formula output, clipped to `[0, 1]`. `details`
-carries the per-task breakdown (which metric was used, the three anchor
-values, plus any family-specific diagnostic fields).
+`reward` is the final composite, clipped to `[0, 1]`. `details` carries
+the per-family metric breakdown, the in-window vs out-window split, and
+the 0.90 / 0.10 mass weights (where applicable).

--- a/tasks/agentic_vbench_repair/exp-codec-restore-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-codec-restore-task01/steps/solve/tests/judge.py
@@ -19,8 +19,11 @@ In-window composite (Codec-SUPERB convention; DNSMOS-OVL headline):
 
 Fallback when DNSMOS is unavailable / out-of-distribution:
 
-  in_window_reward = 0.5 * clip01((PESQ_wb - 1) / 3.5)
-                   + 0.5 * clip01(1 - LSD_4_8kHz / 5)
+  in_window_reward = 0.5 * clip01((PESQ_wb - 2.6) / 1.9)
+                   + 0.5 * clip01(1 - LSD_4_8kHz / 0.9)
+
+(LO=2.6 PESQ and LSD/0.9 are per-task anchors so broken
+passthrough → 0 on the restoration component.)
 
 Out-of-window check (catches over-enhancement of clean regions):
 
@@ -28,7 +31,7 @@ Out-of-window check (catches over-enhancement of clean regions):
 
 Final reward:
 
-  reward = 0.85 * in_window_reward + 0.15 * out_window_reward
+  reward = 0.90 * in_window_reward + 0.10 * out_window_reward
 """
 from __future__ import annotations
 
@@ -47,8 +50,8 @@ from pystoi import stoi
 DNSMOS_MODEL_PATH = Path("/tests/sig_bak_ovr.onnx")
 WINDOW_JSON_PATH = Path("/tests/window.json")
 DNSMOS_INPUT_SAMPLES = int(9.01 * 16000)  # 144160
-IN_WEIGHT = 0.85
-OUT_WEIGHT = 0.15
+IN_WEIGHT = 0.90
+OUT_WEIGHT = 0.10
 
 
 def _clip01(x: float) -> float:
@@ -168,7 +171,7 @@ def _score_in_window(est: np.ndarray, ref: np.ndarray,
     except Exception as e:
         details["dnsmos_error"] = str(e)
 
-    lsd_hi_n = _clip01(1.0 - lsd_hi / 5.0)
+    lsd_hi_n = _clip01(1.0 - lsd_hi / 0.9)
     if dnsmos_ok:
         ovl_n = _clip01((details["dnsmos_ovl"] - 1.0) / 4.0)
         stoi_n = _clip01(stoi_v)
@@ -182,13 +185,13 @@ def _score_in_window(est: np.ndarray, ref: np.ndarray,
             ),
         })
     else:
-        pesq_n = _clip01((pesq_wb - 1.0) / 3.5)
+        pesq_n = _clip01((pesq_wb - 2.6) / 1.9)
         reward = 0.5 * pesq_n + 0.5 * lsd_hi_n
         details.update({
             "pesq_n": pesq_n,
             "lsd_n": lsd_hi_n,
             "composite_formula": (
-                "0.5*clip01((PESQ_wb-1)/3.5) + 0.5*clip01(1 - LSD_4_8kHz/5) "
+                "0.5*clip01((PESQ_wb-2.6)/1.9) + 0.5*clip01(1 - LSD_4_8kHz/0.9) "
                 "[DNSMOS unavailable fallback]"
             ),
         })

--- a/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/steps/solve/tests/gt_window.json
+++ b/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/steps/solve/tests/gt_window.json
@@ -6,8 +6,8 @@
   "fps": 25.0,
   "n_frames_total": 1500,
   "weights": {
-    "in_window": 0.85,
-    "out_window": 0.15
+    "in_window": 0.9,
+    "out_window": 0.1
   },
   "grade_kind": "lut",
   "grade_provenance": "CINEMA_NOIR.cube"

--- a/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/steps/solve/tests/judge.py
@@ -9,7 +9,7 @@ For each frame i:
 
     in_window_score  = 1 - clip(mean(dE_in) / 10.0, 0, 1)   -- ΔE: color-faithful
     out_window_score = 1 if mean(ssim_out) >= 0.95 else 0   -- SSIM: identity gate
-    reward = 0.85 * in_window_score + 0.15 * out_window_score
+    reward = 0.90 * in_window_score + 0.10 * out_window_score
 
 Each window uses the metric appropriate to the question it asks: ΔE for
 restoration quality (in-window), SSIM for content preservation (out-window).
@@ -112,8 +112,8 @@ def main():
         w_start_s = float(win["window_start_s"])
         w_end_s = float(win["window_end_s"])
         w = win.get("weights") or {}
-        w_in = float(w.get("in_window", 0.85))
-        w_out = float(w.get("out_window", 0.15))
+        w_in = float(w.get("in_window", 0.90))
+        w_out = float(w.get("out_window", 0.10))
 
         # Stream-decode all 3 videos frame-by-frame to keep memory bounded
         # (an earlier all-in-memory version OOM'd the 4 GiB container on

--- a/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/steps/solve/tests/gt_window.json
+++ b/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/steps/solve/tests/gt_window.json
@@ -6,8 +6,8 @@
   "fps": 25.0,
   "n_frames_total": 5400,
   "weights": {
-    "in_window": 0.85,
-    "out_window": 0.15
+    "in_window": 0.9,
+    "out_window": 0.1
   },
   "grade_kind": "cdl",
   "grade_provenance": {

--- a/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/steps/solve/tests/judge.py
@@ -9,7 +9,7 @@ For each frame i:
 
     in_window_score  = 1 - clip(mean(dE_in) / 10.0, 0, 1)   -- ΔE: color-faithful
     out_window_score = 1 if mean(ssim_out) >= 0.95 else 0   -- SSIM: identity gate
-    reward = 0.85 * in_window_score + 0.15 * out_window_score
+    reward = 0.90 * in_window_score + 0.10 * out_window_score
 
 Each window uses the metric appropriate to the question it asks: ΔE for
 restoration quality (in-window), SSIM for content preservation (out-window).
@@ -112,8 +112,8 @@ def main():
         w_start_s = float(win["window_start_s"])
         w_end_s = float(win["window_end_s"])
         w = win.get("weights") or {}
-        w_in = float(w.get("in_window", 0.85))
-        w_out = float(w.get("out_window", 0.15))
+        w_in = float(w.get("in_window", 0.90))
+        w_out = float(w.get("out_window", 0.10))
 
         # Stream-decode all 3 videos frame-by-frame to keep memory bounded
         # (an earlier all-in-memory version OOM'd the 4 GiB container on

--- a/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/steps/solve/tests/gt_window.json
+++ b/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/steps/solve/tests/gt_window.json
@@ -6,8 +6,8 @@
   "fps": 24.0,
   "n_frames_total": 721,
   "weights": {
-    "in_window": 0.85,
-    "out_window": 0.15
+    "in_window": 0.9,
+    "out_window": 0.1
   },
   "grade_kind": "lut",
   "grade_provenance": "Bourbon_64.CUBE"

--- a/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/steps/solve/tests/judge.py
@@ -9,7 +9,7 @@ For each frame i:
 
     in_window_score  = 1 - clip(mean(dE_in) / 10.0, 0, 1)   -- ΔE: color-faithful
     out_window_score = 1 if mean(ssim_out) >= 0.95 else 0   -- SSIM: identity gate
-    reward = 0.85 * in_window_score + 0.15 * out_window_score
+    reward = 0.90 * in_window_score + 0.10 * out_window_score
 
 Each window uses the metric appropriate to the question it asks: ΔE for
 restoration quality (in-window), SSIM for content preservation (out-window).
@@ -112,8 +112,8 @@ def main():
         w_start_s = float(win["window_start_s"])
         w_end_s = float(win["window_end_s"])
         w = win.get("weights") or {}
-        w_in = float(w.get("in_window", 0.85))
-        w_out = float(w.get("out_window", 0.15))
+        w_in = float(w.get("in_window", 0.90))
+        w_out = float(w.get("out_window", 0.10))
 
         # Stream-decode all 3 videos frame-by-frame to keep memory bounded
         # (an earlier all-in-memory version OOM'd the 4 GiB container on

--- a/tasks/agentic_vbench_repair/exp-deblur-gaussian-mkbhd-task01/steps/solve/tests/gt_window.json
+++ b/tasks/agentic_vbench_repair/exp-deblur-gaussian-mkbhd-task01/steps/solve/tests/gt_window.json
@@ -5,7 +5,7 @@
   "window_end_frame": 658,
   "fps": 30,
   "weights": {
-    "in_window": 0.85,
-    "out_window": 0.15
+    "in_window": 0.9,
+    "out_window": 0.1
   }
 }

--- a/tasks/agentic_vbench_repair/exp-deblur-gaussian-mkbhd-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-deblur-gaussian-mkbhd-task01/steps/solve/tests/judge.py
@@ -1,35 +1,29 @@
 #!/usr/bin/env python3
-"""Masked-region video repair judge.
+"""Masked-region deblur judge.
 
 Loads `output.mp4`, `clean.mp4`, `corrupted.mp4`, and `mask.png`. For each
-frame pair, computes:
+frame pair, computes PSNR-Y and SSIM-Y over masked pixels (restoration
+quality) plus SSIM gates outside the mask (preservation).
 
-  * in-mask metric: distance from agent output to CLEAN reference
-    - color task: mean CIEDE2000 (ΔE2000) over masked pixels
-    - deblur task: PSNR-Y and SSIM-Y over masked pixels
-  * out-mask preservation metric: agent output vs the (corrupted) input
-    in non-masked pixels. The agent should not touch outside the mask;
-    untouched pixels score perfectly here.
-    - color task: mean ΔE2000 (lower = closer to corrupted = better
-      preservation)
-    - deblur task: PSNR (higher = closer to corrupted = better
-      preservation)
+In-window restoration (in-mask, output vs clean):
 
-Mapping to [0, 1]:
-  color   in_score  = clip01(1 - mean_dE_in / 10)   # tightened from /30
-  color   out_score = clip01(1 - mean_dE_out / 5)
-  deblur  in_score  = clip01((PSNR_in - 18) / 14)   # tightened from (PSNR-15)/25
-                       blended 0.5/0.5 with clip01((SSIM_in - 0.6) / 0.4)
-  deblur  out_score = clip01((PSNR_out - 30) / 20)
+  psnr_n  = clip01((mean_PSNR_in - 31.0) / 9.0)
+  ssim_n  = clip01((mean_SSIM_in - 0.93) / 0.07)
+  restore = 0.5 * psnr_n + 0.5 * ssim_n
 
-Composite: reward = 0.7 * in_score + 0.3 * out_score.
+In-window preservation (in-window, out-of-mask, output vs corrupted) and
+out-of-window preservation are binary SSIM gates at 0.95. The in-window
+preservation gate is multiplicative: a fail zeroes the in-window score.
+The out-window preservation gate contributes the 10% preservation mass.
 
-Why tightened: the user's nominal corruption recipe (hue ±10-15deg, sat
-x0.5/x1.2; Gaussian sigma=3 ksize=15; motion length=15px) produces mild
-perceptual deltas (mean dE2000 ~3-6; mean masked PSNR ~25-27 dB). Under
-the original /30 and /25 divisors a do-nothing passthrough scored
-0.74-0.92, leaving no signal for the agent. Tightened divisors land the
-passthrough baseline near 0.50, matching the spec target ~0.51.
+Final:
+
+  in_window_score = restore if in_win_preserve_pass else 0
+  reward = 0.90 * in_window_score + 0.10 * out_window_score
+
+Per-task anchors (PSNR LO=31 dB, SSIM LO=0.93) derived from broken
+passthrough measurements (~28-30 dB / ~0.87-0.93). Broken floor lands
+at 0.10 (preservation mass only); golden identity lands at 1.0.
 """
 from __future__ import annotations
 
@@ -139,7 +133,7 @@ def _load_window(path: Path | None, n_frames: int, fps_hint: float):
 
     gt_window.json shape:
       {"window_start_s": float, "window_end_s": float, "fps": float,
-       "weights": {"in_window": 0.85, "out_window": 0.15}}
+       "weights": {"in_window": 0.90, "out_window": 0.10}}
     """
     if path is None or not path.exists():
         return None
@@ -152,8 +146,8 @@ def _load_window(path: Path | None, n_frames: int, fps_hint: float):
     if end_f <= start_f:
         return None
     w = data.get("weights") or {}
-    w_in = float(w.get("in_window", 0.85))
-    w_out = float(w.get("out_window", 0.15))
+    w_in = float(w.get("in_window", 0.90))
+    w_out = float(w.get("out_window", 0.10))
     return start_f, end_f, w_in, w_out
 
 
@@ -265,16 +259,17 @@ def score_deblur(out_frames, clean_frames, corr_frames, mask, window) -> dict:
     mean_psnr_in = float(np.mean(in_win_psnr)) if in_win_psnr else 0.0
     mean_ssim_in = float(np.mean(in_win_ssim)) if in_win_ssim else 0.0
     if in_win_psnr:
-        psnr_part = _clip01((mean_psnr_in - 22.0) / 13.0)
-        ssim_part = _clip01((mean_ssim_in - 0.75) / 0.25)
+        psnr_part = _clip01((mean_psnr_in - 31.0) / 9.0)
+        ssim_part = _clip01((mean_ssim_in - 0.93) / 0.07)
         restore = 0.5 * psnr_part + 0.5 * ssim_part
     else:
         restore = 1.0
     mean_in_win_preserve_ssim = float(np.mean(in_win_preserve_ssim)) if in_win_preserve_ssim else 1.0
     in_win_preserve_pass = mean_in_win_preserve_ssim >= OUT_WINDOW_SSIM_THRESHOLD
     in_win_preserve = 1.0 if in_win_preserve_pass else 0.0
+    # Preservation is a binary GATE, not a score component — pass-or-zero.
     if in_win_preserve_ssim:
-        in_window_score = 0.7 * restore + 0.3 * in_win_preserve
+        in_window_score = restore if in_win_preserve_pass else 0.0
     else:
         in_window_score = restore  # full-frame mask
     mean_out_win_ssim = float(np.mean(out_win_ssim)) if out_win_ssim else 1.0

--- a/tasks/agentic_vbench_repair/exp-deblur-motion-f1-task01/steps/solve/tests/gt_window.json
+++ b/tasks/agentic_vbench_repair/exp-deblur-motion-f1-task01/steps/solve/tests/gt_window.json
@@ -5,7 +5,7 @@
   "window_end_frame": 521,
   "fps": 30,
   "weights": {
-    "in_window": 0.85,
-    "out_window": 0.15
+    "in_window": 0.9,
+    "out_window": 0.1
   }
 }

--- a/tasks/agentic_vbench_repair/exp-deblur-motion-f1-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-deblur-motion-f1-task01/steps/solve/tests/judge.py
@@ -1,35 +1,29 @@
 #!/usr/bin/env python3
-"""Masked-region video repair judge.
+"""Masked-region deblur judge.
 
 Loads `output.mp4`, `clean.mp4`, `corrupted.mp4`, and `mask.png`. For each
-frame pair, computes:
+frame pair, computes PSNR-Y and SSIM-Y over masked pixels (restoration
+quality) plus SSIM gates outside the mask (preservation).
 
-  * in-mask metric: distance from agent output to CLEAN reference
-    - color task: mean CIEDE2000 (ΔE2000) over masked pixels
-    - deblur task: PSNR-Y and SSIM-Y over masked pixels
-  * out-mask preservation metric: agent output vs the (corrupted) input
-    in non-masked pixels. The agent should not touch outside the mask;
-    untouched pixels score perfectly here.
-    - color task: mean ΔE2000 (lower = closer to corrupted = better
-      preservation)
-    - deblur task: PSNR (higher = closer to corrupted = better
-      preservation)
+In-window restoration (in-mask, output vs clean):
 
-Mapping to [0, 1]:
-  color   in_score  = clip01(1 - mean_dE_in / 10)   # tightened from /30
-  color   out_score = clip01(1 - mean_dE_out / 5)
-  deblur  in_score  = clip01((PSNR_in - 18) / 14)   # tightened from (PSNR-15)/25
-                       blended 0.5/0.5 with clip01((SSIM_in - 0.6) / 0.4)
-  deblur  out_score = clip01((PSNR_out - 30) / 20)
+  psnr_n  = clip01((mean_PSNR_in - 31.0) / 9.0)
+  ssim_n  = clip01((mean_SSIM_in - 0.93) / 0.07)
+  restore = 0.5 * psnr_n + 0.5 * ssim_n
 
-Composite: reward = 0.7 * in_score + 0.3 * out_score.
+In-window preservation (in-window, out-of-mask, output vs corrupted) and
+out-of-window preservation are binary SSIM gates at 0.95. The in-window
+preservation gate is multiplicative: a fail zeroes the in-window score.
+The out-window preservation gate contributes the 10% preservation mass.
 
-Why tightened: the user's nominal corruption recipe (hue ±10-15deg, sat
-x0.5/x1.2; Gaussian sigma=3 ksize=15; motion length=15px) produces mild
-perceptual deltas (mean dE2000 ~3-6; mean masked PSNR ~25-27 dB). Under
-the original /30 and /25 divisors a do-nothing passthrough scored
-0.74-0.92, leaving no signal for the agent. Tightened divisors land the
-passthrough baseline near 0.50, matching the spec target ~0.51.
+Final:
+
+  in_window_score = restore if in_win_preserve_pass else 0
+  reward = 0.90 * in_window_score + 0.10 * out_window_score
+
+Per-task anchors (PSNR LO=31 dB, SSIM LO=0.93) derived from broken
+passthrough measurements (~28-30 dB / ~0.87-0.93). Broken floor lands
+at 0.10 (preservation mass only); golden identity lands at 1.0.
 """
 from __future__ import annotations
 
@@ -139,7 +133,7 @@ def _load_window(path: Path | None, n_frames: int, fps_hint: float):
 
     gt_window.json shape:
       {"window_start_s": float, "window_end_s": float, "fps": float,
-       "weights": {"in_window": 0.85, "out_window": 0.15}}
+       "weights": {"in_window": 0.90, "out_window": 0.10}}
     """
     if path is None or not path.exists():
         return None
@@ -152,8 +146,8 @@ def _load_window(path: Path | None, n_frames: int, fps_hint: float):
     if end_f <= start_f:
         return None
     w = data.get("weights") or {}
-    w_in = float(w.get("in_window", 0.85))
-    w_out = float(w.get("out_window", 0.15))
+    w_in = float(w.get("in_window", 0.90))
+    w_out = float(w.get("out_window", 0.10))
     return start_f, end_f, w_in, w_out
 
 
@@ -265,16 +259,17 @@ def score_deblur(out_frames, clean_frames, corr_frames, mask, window) -> dict:
     mean_psnr_in = float(np.mean(in_win_psnr)) if in_win_psnr else 0.0
     mean_ssim_in = float(np.mean(in_win_ssim)) if in_win_ssim else 0.0
     if in_win_psnr:
-        psnr_part = _clip01((mean_psnr_in - 22.0) / 13.0)
-        ssim_part = _clip01((mean_ssim_in - 0.75) / 0.25)
+        psnr_part = _clip01((mean_psnr_in - 31.0) / 9.0)
+        ssim_part = _clip01((mean_ssim_in - 0.93) / 0.07)
         restore = 0.5 * psnr_part + 0.5 * ssim_part
     else:
         restore = 1.0
     mean_in_win_preserve_ssim = float(np.mean(in_win_preserve_ssim)) if in_win_preserve_ssim else 1.0
     in_win_preserve_pass = mean_in_win_preserve_ssim >= OUT_WINDOW_SSIM_THRESHOLD
     in_win_preserve = 1.0 if in_win_preserve_pass else 0.0
+    # Preservation is a binary GATE, not a score component — pass-or-zero.
     if in_win_preserve_ssim:
-        in_window_score = 0.7 * restore + 0.3 * in_win_preserve
+        in_window_score = restore if in_win_preserve_pass else 0.0
     else:
         in_window_score = restore  # full-frame mask
     mean_out_win_ssim = float(np.mean(out_win_ssim)) if out_win_ssim else 1.0

--- a/tasks/agentic_vbench_repair/exp-declip-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-declip-task01/steps/solve/tests/judge.py
@@ -12,9 +12,12 @@ Transformer 2024):
 
 In-window composite (URGENT 2024 + SDT 2024 convention):
 
-  in_window_reward = 0.5 * clip01((masked_SI_SDR + 5) / 25)
-                   + 0.3 * ESTOI
-                   + 0.2 * clip01((PESQ_wb - 1) / 3.5)
+  in_window_reward = 0.5 * clip01((masked_SI_SDR - 14) / 16)
+                   + 0.3 * clip01((ESTOI - 0.96) / 0.04)
+                   + 0.2 * clip01((PESQ_wb - 3.4) / 1.1)
+
+(Per-task LO anchors: msSI-SDR=14 dB, ESTOI=0.96, PESQ=3.4 —
+derived from the broken passthrough measurements.)
 
 Out-of-window check (catches over-enhancement of clean regions):
 
@@ -22,7 +25,7 @@ Out-of-window check (catches over-enhancement of clean regions):
 
 Final reward:
 
-  reward = 0.85 * in_window_reward + 0.15 * out_window_reward
+  reward = 0.90 * in_window_reward + 0.10 * out_window_reward
 """
 from __future__ import annotations
 
@@ -38,8 +41,8 @@ from pystoi import stoi
 
 
 WINDOW_JSON_PATH = Path("/tests/window.json")
-IN_WEIGHT = 0.85
-OUT_WEIGHT = 0.15
+IN_WEIGHT = 0.90
+OUT_WEIGHT = 0.10
 
 
 def _clip01(x: float) -> float:
@@ -94,17 +97,17 @@ def _score_in_window(est: np.ndarray, ref: np.ndarray,
         msisdr = _masked_si_sdr(ref, est, mask)
     details["masked_si_sdr_db"] = msisdr
 
-    msisdr_n = _clip01((msisdr + 5.0) / 25.0)
-    estoi_n = _clip01(estoi_v)
-    pesq_n = _clip01((pesq_wb - 1.0) / 3.5)
+    msisdr_n = _clip01((msisdr - 14.0) / 16.0)
+    estoi_n = _clip01((estoi_v - 0.96) / 0.04)
+    pesq_n = _clip01((pesq_wb - 3.4) / 1.1)
     reward = 0.5 * msisdr_n + 0.3 * estoi_n + 0.2 * pesq_n
     details.update({
         "msisdr_n": msisdr_n,
         "estoi_n": estoi_n,
         "pesq_n": pesq_n,
         "composite_formula": (
-            "0.5*clip01((masked_SI_SDR+5)/25) + 0.3*ESTOI "
-            "+ 0.2*clip01((PESQ_wb-1)/3.5)"
+            "0.5*clip01((masked_SI_SDR-14)/16) + 0.3*clip01((ESTOI-0.96)/0.04) "
+            "+ 0.2*clip01((PESQ_wb-3.4)/1.1)"
         ),
     })
     return float(reward), details

--- a/tasks/agentic_vbench_repair/exp-dereverb-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-dereverb-task01/steps/solve/tests/judge.py
@@ -12,9 +12,12 @@ Paper-standard metric battery (REVERB Challenge 2014; Kinoshita et al.):
 
 In-window composite (REVERB-Challenge style):
 
-  in_window_reward = 0.4 * clip01((PESQ_wb - 1) / 3.5)
-                   + 0.3 * STOI
-                   + 0.3 * clip01(1 - CD/8)
+  in_window_reward = 0.4 * clip01((PESQ_wb - 1.3) / 3.2)
+                   + 0.3 * clip01((STOI - 0.20) / 0.80)
+                   + 0.3 * clip01(1 - CD/5)
+
+(Per-task LO anchors: PESQ=1.3, STOI=0.20, CD divisor=5 —
+derived from the broken passthrough measurements.)
 
 Out-of-window check (catches over-enhancement of clean regions):
 
@@ -22,7 +25,7 @@ Out-of-window check (catches over-enhancement of clean regions):
 
 Final reward:
 
-  reward = 0.85 * in_window_reward + 0.15 * out_window_reward
+  reward = 0.90 * in_window_reward + 0.10 * out_window_reward
 """
 from __future__ import annotations
 
@@ -38,8 +41,8 @@ from pystoi import stoi
 
 
 WINDOW_JSON_PATH = Path("/tests/window.json")
-IN_WEIGHT = 0.85
-OUT_WEIGHT = 0.15
+IN_WEIGHT = 0.90
+OUT_WEIGHT = 0.10
 
 
 def _clip01(x: float) -> float:
@@ -96,16 +99,16 @@ def _score_in_window(est: np.ndarray, ref: np.ndarray) -> tuple[float, dict]:
     except Exception as e:
         details["srmr_error"] = str(e)
 
-    pesq_n = _clip01((pesq_wb - 1.0) / 3.5)
-    stoi_n = _clip01(stoi_v)
-    cd_n = _clip01(1.0 - cd_val / 8.0)
+    pesq_n = _clip01((pesq_wb - 1.3) / 3.2)
+    stoi_n = _clip01((stoi_v - 0.20) / 0.80)
+    cd_n = _clip01(1.0 - cd_val / 5.0)
     reward = 0.4 * pesq_n + 0.3 * stoi_n + 0.3 * cd_n
     details.update({
         "pesq_n": pesq_n,
         "stoi_n": stoi_n,
         "cd_n": cd_n,
         "composite_formula": (
-            "0.4*clip01((PESQ_wb-1)/3.5) + 0.3*STOI + 0.3*clip01(1 - CD/8)"
+            "0.4*clip01((PESQ_wb-1.3)/3.2) + 0.3*clip01((STOI-0.20)/0.80) + 0.3*clip01(1 - CD/5)"
         ),
     })
     return float(reward), details

--- a/tasks/agentic_vbench_repair/exp-dns-denoise-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-dns-denoise-task01/steps/solve/tests/judge.py
@@ -19,8 +19,12 @@ In-window composite (DNS-Challenge convention; DNSMOS-OVL is the headline):
 If DNSMOS fails (model missing / onnxruntime missing), fall back to:
 
   in_window_reward = 0.4 * clip01((PESQ_wb - 1) / 3.5)
-                   + 0.3 * STOI
-                   + 0.3 * clip01((SI-SDR + 10) / 30)
+                   + 0.3 * clip01((STOI - 0.86) / 0.14)
+                   + 0.3 * clip01((SI-SDR - 4) / 16)
+
+(Per-task LO anchors: STOI=0.86, SI-SDR=4 dB — derived from the
+broken passthrough measurements. PESQ already lands near 0
+naturally on a noisy signal.)
 
 Out-of-window check (catches over-enhancement of clean regions):
 
@@ -28,7 +32,7 @@ Out-of-window check (catches over-enhancement of clean regions):
 
 Final reward (convex combination, fixed mass):
 
-  reward = 0.85 * in_window_reward + 0.15 * out_window_reward
+  reward = 0.90 * in_window_reward + 0.10 * out_window_reward
 """
 from __future__ import annotations
 
@@ -46,8 +50,8 @@ from pystoi import stoi
 DNSMOS_MODEL_PATH = Path("/tests/sig_bak_ovr.onnx")
 WINDOW_JSON_PATH = Path("/tests/window.json")
 DNSMOS_INPUT_SAMPLES = int(9.01 * 16000)  # 144160
-IN_WEIGHT = 0.85
-OUT_WEIGHT = 0.15
+IN_WEIGHT = 0.90
+OUT_WEIGHT = 0.10
 
 
 def _clip01(x: float) -> float:
@@ -147,8 +151,8 @@ def _score_in_window(est: np.ndarray, ref: np.ndarray,
 
     if dnsmos_ok:
         ovl_n = _clip01((details["dnsmos_ovl"] - 1.0) / 4.0)
-        stoi_n = _clip01(stoi_v)
-        sisdr_n = _clip01((sisdr_db + 10.0) / 30.0)
+        stoi_n = _clip01((stoi_v - 0.86) / 0.14)
+        sisdr_n = _clip01((sisdr_db - 4.0) / 16.0)
         reward = 0.5 * ovl_n + 0.3 * stoi_n + 0.2 * sisdr_n
         details["composite_formula"] = (
             "0.5*clip01((DNSMOS_OVL-1)/4) + 0.3*STOI + 0.2*clip01((SI-SDR+10)/30)"
@@ -156,11 +160,11 @@ def _score_in_window(est: np.ndarray, ref: np.ndarray,
         details.update({"ovl_n": ovl_n, "stoi_n": stoi_n, "sisdr_n": sisdr_n})
     else:
         pesq_n = _clip01((pesq_wb - 1.0) / 3.5)
-        stoi_n = _clip01(stoi_v)
-        sisdr_n = _clip01((sisdr_db + 10.0) / 30.0)
+        stoi_n = _clip01((stoi_v - 0.86) / 0.14)
+        sisdr_n = _clip01((sisdr_db - 4.0) / 16.0)
         reward = 0.4 * pesq_n + 0.3 * stoi_n + 0.3 * sisdr_n
         details["composite_formula"] = (
-            "0.4*clip01((PESQ_wb-1)/3.5) + 0.3*STOI + 0.3*clip01((SI-SDR+10)/30) "
+            "0.4*clip01((PESQ_wb-1)/3.5) + 0.3*clip01((STOI-0.86)/0.14) + 0.3*clip01((SI-SDR-4)/16) "
             "[DNSMOS unavailable fallback]"
         )
         details.update({"pesq_n": pesq_n, "stoi_n": stoi_n, "sisdr_n": sisdr_n})

--- a/tasks/agentic_vbench_repair/exp-sr-2x-shot-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-sr-2x-shot-task01/steps/solve/tests/judge.py
@@ -4,8 +4,8 @@
 Components:
   - localization_iou: 1-D IoU between agent range and GT range.
   - quality_score:    in-shot PSNR-Y + SSIM-Y vs held-out original.
-                      psnr_n = clip01((mean_PSNR - 15) / 25)
-                      ssim_n = clip01(mean_SSIM)
+                      psnr_n = clip01((mean_PSNR - 38) / 7)
+                      ssim_n = clip01((mean_SSIM - 0.975) / 0.025)
                       quality_score = 0.5 * psnr_n + 0.5 * ssim_n
   - out_score:        min(mean_PSNR(input, output, frames OUTSIDE agent
                                     range) / 50, 1.0)
@@ -153,8 +153,8 @@ def score(output_mp4: Path, output_json: Path, gt_shot_json: Path,
                      agent_range=[agent_lo, agent_hi], gt_range=[gt_lo, gt_hi])
     mean_psnr_in = float(np.mean(psnrs))
     mean_ssim_in = float(np.mean(ssims))
-    psnr_n = _clip01((mean_psnr_in - 15.0) / 25.0)
-    ssim_n = _clip01(mean_ssim_in)
+    psnr_n = _clip01((mean_psnr_in - 38.0) / 7.0)
+    ssim_n = _clip01((mean_ssim_in - 0.975) / 0.025)
     quality_score = 0.5 * psnr_n + 0.5 * ssim_n
 
     # ---- preservation: out-of-range SSIM between corrupted input and output ----

--- a/tasks/agentic_vbench_repair/exp-sr-4x-shot-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-sr-4x-shot-task01/steps/solve/tests/judge.py
@@ -4,8 +4,8 @@
 Components:
   - localization_iou: 1-D IoU between agent range and GT range.
   - quality_score:    in-shot PSNR-Y + SSIM-Y vs held-out original.
-                      psnr_n = clip01((mean_PSNR - 15) / 25)
-                      ssim_n = clip01(mean_SSIM)
+                      psnr_n = clip01((mean_PSNR - 22) / 13)
+                      ssim_n = clip01((mean_SSIM - 0.80) / 0.20)
                       quality_score = 0.5 * psnr_n + 0.5 * ssim_n
   - out_score:        min(mean_PSNR(input, output, frames OUTSIDE agent
                                     range) / 50, 1.0)
@@ -153,8 +153,8 @@ def score(output_mp4: Path, output_json: Path, gt_shot_json: Path,
                      agent_range=[agent_lo, agent_hi], gt_range=[gt_lo, gt_hi])
     mean_psnr_in = float(np.mean(psnrs))
     mean_ssim_in = float(np.mean(ssims))
-    psnr_n = _clip01((mean_psnr_in - 15.0) / 25.0)
-    ssim_n = _clip01(mean_ssim_in)
+    psnr_n = _clip01((mean_psnr_in - 22.0) / 13.0)
+    ssim_n = _clip01((mean_ssim_in - 0.80) / 0.20)
     quality_score = 0.5 * psnr_n + 0.5 * ssim_n
 
     # ---- preservation: out-of-range SSIM between corrupted input and output ----

--- a/tasks/agentic_vbench_repair/exp-swap-car-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-swap-car-task01/steps/solve/tests/judge.py
@@ -2,7 +2,9 @@
 """Shot-swap restoration judge.
 
 Composite reward = whole-video mean PSNR (output.mp4 vs original.mp4),
-normalised to [0, 1] via linear map of [10, 40] dB.
+normalised to [0, 1] via linear map of [17, 40] dB.
+(LO=17 dB anchors broken-passthrough whole-video PSNR≈16 dB
+→ broken floor 0.0; identity → 1.0.)
 
 Diagnostics (NOT in composite, reported in details):
 - detection_score: IoU between agent-reported swap ranges and GT swap
@@ -20,7 +22,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 
-PSNR_LO = 10.0
+PSNR_LO = 17.0
 PSNR_HI = 40.0
 LEN_TOL = 0.10  # 10% length deviation = heavy penalty
 

--- a/tasks/agentic_vbench_repair/exp-swap-product-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-swap-product-task01/steps/solve/tests/judge.py
@@ -2,7 +2,9 @@
 """Shot-swap restoration judge.
 
 Composite reward = whole-video mean PSNR (output.mp4 vs original.mp4),
-normalised to [0, 1] via linear map of [10, 40] dB.
+normalised to [0, 1] via linear map of [17, 40] dB.
+(LO=17 dB anchors broken-passthrough whole-video PSNR≈16 dB
+→ broken floor 0.0; identity → 1.0.)
 
 Diagnostics (NOT in composite, reported in details):
 - detection_score: IoU between agent-reported swap ranges and GT swap
@@ -20,7 +22,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 
-PSNR_LO = 10.0
+PSNR_LO = 17.0
 PSNR_HI = 40.0
 LEN_TOL = 0.10  # 10% length deviation = heavy penalty
 

--- a/tasks/agentic_vbench_repair/exp-voicebank-denoise-task01/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repair/exp-voicebank-denoise-task01/steps/solve/tests/judge.py
@@ -10,9 +10,17 @@ Paper-standard metric battery (Valentini-Botinhao SSW 2016 + Hu & Loizou
   - COVL     (composite overall MOS, 1-5)
   - SSNR     (segmental SNR in dB)
 
-In-window composite (Valentini-Botinhao convention):
+In-window composite (Valentini-Botinhao convention,
+per-component LO-anchored mean):
 
-  in_window_reward = clip01((CSIG + CBAK + COVL) / 15)
+  in_window_reward = clip01(
+      ( clip01((CSIG - 4.0) / 1.0)
+      + clip01((CBAK - 2.8) / 2.2)
+      + clip01((COVL - 3.1) / 1.9) ) / 3
+  )
+
+(Per-task LO anchors derived from the broken passthrough
+measurements; flat (CSIG+CBAK+COVL)/15 gave broken floor 0.66.)
 
 Out-of-window check (catches over-enhancement of clean regions):
 
@@ -20,7 +28,7 @@ Out-of-window check (catches over-enhancement of clean regions):
 
 Final reward:
 
-  reward = 0.85 * in_window_reward + 0.15 * out_window_reward
+  reward = 0.90 * in_window_reward + 0.10 * out_window_reward
 """
 from __future__ import annotations
 
@@ -35,8 +43,8 @@ from pesq import pesq
 
 
 WINDOW_JSON_PATH = Path("/tests/window.json")
-IN_WEIGHT = 0.85
-OUT_WEIGHT = 0.15
+IN_WEIGHT = 0.90
+OUT_WEIGHT = 0.10
 
 
 def _clip01(x: float) -> float:
@@ -79,8 +87,8 @@ def _score_in_window(est: np.ndarray, ref: np.ndarray) -> tuple[float, dict]:
         details["ssnr_db"] = float(pysepm.SNRseg(ref_f, est_f, 16000))
     except Exception as e:
         details["ssnr_error"] = str(e)
-    reward = _clip01((csig + cbak + covl) / 15.0)
-    details["composite_formula"] = "(CSIG + CBAK + COVL) / 15"
+    reward = _clip01((_clip01((csig - 4.0) / 1.0) + _clip01((cbak - 2.8) / 2.2) + _clip01((covl - 3.1) / 1.9)) / 3.0)
+    details["composite_formula"] = "(clip01((CSIG-4)/1) + clip01((CBAK-2.8)/2.2) + clip01((COVL-3.1)/1.9)) / 3"
     return float(reward), details
 
 


### PR DESCRIPTION
## Summary

The 20 baked repair verifiers in `tasks/agentic_vbench_repair/` were giving generous credit to a *broken passthrough* — an agent that copies the corrupted input straight through and does no repair work. Floors ran 0.15–0.83 on 14 of 20 tasks despite the design doc promising broken=0 / golden=1.

This PR re-anchors every restoration metric so broken passthrough lands at **≤ 0.10** (the explicit preservation reservation) and golden identity still lands at **1.000**.

### Per-family floor (broken → broken_after, golden_after)

| Family | Before | After | Golden |
|---|---|---|---|
| Cut / disfluency / glitch (6) | 0.000 | 0.000 | 1.000 |
| Color-shot (3) | 0.150 | **0.100** | 1.000 |
| Deblur (2) | 0.703 / 0.722 | **0.100** | 1.000 |
| SR (2) | 0.761 / 0.470 | **0.100** | 1.000 |
| Swap (2) | 0.208 / 0.201 | **0.000** | 1.000 |
| Audio (5) | 0.34–0.83 | **0.104–0.120** | 1.000 |

### What changed in code

Three orthogonal fixes:

- **Preservation cap → 10%** (was 15–30% across families). Updated `gt_window.json` weights for color+deblur and `IN_WEIGHT`/`OUT_WEIGHT` constants in the 5 audio judges.
- **Deblur preservation-twice bug**: `in_win_preserve` was both a multiplicative gate and a 30% additive component in `in_window_score`. Made it strictly multiplicative — pass-or-zero.
- **Per-task restoration tightening**: each restoration metric's LO/HI thresholds re-anchored to the actually-measured broken passthrough value (e.g. deblur PSNR LO=22→31, SR-2x PSNR LO=15→38, SR-4x PSNR LO=15→22, swap PSNR LO=10→17, codec-restore PESQ LO=1→2.6 / LSD divisor 5→0.9, etc.). Numbers derived directly from broken-floor `reward.json` measurements, not guessed.

### Doc + housekeeping

- `docs/VERIFIER_DESIGN.md` updated to reflect the 10% preservation reservation and the actual per-family metrics in use. Kept honest about what's still divergent from the pure normalize-improvement target.
- `.gitignore` adds `tasks/agentic_vbench_repair/exp-codec-restore-task*/steps/solve/tests/window.json` (Method-1 codec-restore GT JSON is extracted from the HF materials zip at trial time and was untracked-but-not-ignored).

## Test plan

- [x] Pre-flight: `python -m py_compile` clean on all 20 baked judges.
- [x] 20 broken-passthrough trials on Modal (`-a oracle` against an experiment-only sibling that passes through the corrupted input). All hit ≤ 0.120.
- [x] 14 golden-passthrough trials on Modal (`-a oracle` against the existing bundled-golden source tasks). All hit 1.000.
- [ ] Re-run a baseline rollout against this branch to see how the agent reward distribution shifts under the corrected floor. Out of scope for this PR.

## Deferred

The design doc's "universal normalize-improvement" formulation with explicit `{m_broken, m_golden}` anchor JSON per task is the eventual target. The current implementation is equivalent math (broken anchored to LO, golden anchored to HI) but with hardcoded thresholds per task rather than runtime anchors. Switching to runtime anchor JSON would be a follow-up PR — relevant when we want the same metric formula to apply cleanly across multiple source clips per family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)