### PR TITLE
chore: bundle Daytona executor in default install

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,28 +42,44 @@ normalization; sequencing uses a composite
 
 ## Quick start
 
+### Install
+
 ```bash
-# 1. Install Harbor (pinned)
+# Installs Harbor (pinned to a known version) with the Modal + Daytona
+# cloud extras. `-e docker` (local) needs no extras. See
+# `scripts/install-harbor.sh` for what's pinned and how to add more
+# cloud executors (e2b, runloop, gke, etc.).
 ./scripts/install-harbor.sh
+```
 
-# 2. Local Python env (only needed for the rollout wrapper)
-python3 -m venv .venv
-.venv/bin/pip install --upgrade pip
+That single command is the full dependency setup — the rollout wrapper
+(`scripts/parallel_rollout.py`) uses only the Python stdlib.
 
-# 3. Run one task locally on Docker, oracle mode (sanity check — expect reward ≈ 1.0)
+### Smoke-test one task locally
+
+```bash
+# Expect reward ≈ 1.0 (oracle ships the golden answer).
 harbor run -p tasks/agentic_vbench_repair/exp-codec-restore-task01 \
            -e docker -a oracle
+```
 
-# 4. Run the full suite on Modal with claude-code as the agent
+### Run the full suite on a cloud executor
+
+```bash
 export ANTHROPIC_API_KEY=...
+
+# Modal (default cloud target — set up via `modal token new`)
 export MODAL_TOKEN_ID=... MODAL_TOKEN_SECRET=...
 
-.venv/bin/python scripts/parallel_rollout.py \
+# OR Daytona
+export DAYTONA_API_KEY=...
+
+python scripts/parallel_rollout.py \
     --mode claude --env modal --max-parallel 20 \
     --tasks $(ls tasks/agentic_vbench_repair/ | tr '\n' ' ')
 
 # Same pattern for the other two families:
-.venv/bin/python scripts/parallel_rollout.py \
+python scripts/parallel_rollout.py \
     --mode claude --env modal --max-parallel 20 \
     --tasks $(ls tasks/agentic_vbench_assembly/ | tr '\n' ' ')
 ```

--- a/scripts/install-harbor.sh
+++ b/scripts/install-harbor.sh
@@ -2,9 +2,16 @@
 # Pin Harbor to a known version so trial outputs are reproducible.
 # Bump HARBOR_VERSION when intentionally upgrading; check release notes at
 # https://github.com/laude-institute/harbor/releases.
+#
+# Extras installed:
+#   - modal    — required for `-e modal`   (sandbox runs on Modal)
+#   - daytona  — required for `-e daytona` (sandbox runs on Daytona)
+# `-e docker` (local) works without any extra. Add more cloud executors
+# (e2b, runloop, gke, etc.) by extending the bracketed list below — see
+# `harbor run --help` for the full list.
 set -euo pipefail
 
 HARBOR_VERSION="0.6.6"
 
-uv tool install --force "harbor[modal]==${HARBOR_VERSION}"
+uv tool install --force "harbor[modal,daytona]==${HARBOR_VERSION}"
 harbor --version


### PR DESCRIPTION
## Summary

Single-step install for both supported cloud executors:

```bash
./scripts/install-harbor.sh
```

Now installs `harbor[modal,daytona]==0.6.6`. Previously only `[modal]`,
so users wanting to run on Daytona had to know to reinstall manually.
README's Quick Start refreshed to surface this — both `MODAL_TOKEN_ID`
and `DAYTONA_API_KEY` paths shown, and noted that the rollout wrapper
is stdlib-only (no separate requirements file).

## Test plan

- [x] `./scripts/install-harbor.sh` runs cleanly, `harbor --version` reports 0.6.6
- [x] `harbor run -e daytona -a oracle …` reaches container build phase (was previously erroring with `MissingExtraError: harbor[daytona]`)
- Separate finding (out of scope for this PR): Daytona sandboxes appear to block outbound to `huggingface.co` (TCP RST mid-TLS), so Method-1 tasks that curl materials at trial time fail. Method-2 tasks with bundled materials run fine — `exp-dns-denoise-task01` oracle hit reward 1.0 on Daytona in 57s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)