### PR TITLE
feat: SSIM honesty gate for assembly + sequencing verifiers

### DIFF
--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['10.mp4', '4.mp4', '6.mp4', '8.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['10.mp4', '4.mp4', '6.mp4', '8.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['7.mp4', '5.mp4', '1.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['7.mp4', '5.mp4', '1.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['5.mp4', '4.mp4', '9.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['5.mp4', '4.mp4', '9.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['7.mp4', '6.mp4', '2.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['7.mp4', '6.mp4', '2.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['10.mp4', '12.mp4', '11.mp4', '5.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['10.mp4', '12.mp4', '11.mp4', '5.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['8.mp4', '9.mp4', '2.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['8.mp4', '9.mp4', '2.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['4.mp4', '9.mp4', '2.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['4.mp4', '9.mp4', '2.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['5.mp4', '7.mp4', '6.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['5.mp4', '7.mp4', '6.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['6.mp4', '5.mp4', '1.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['6.mp4', '5.mp4', '1.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['6.mp4', '4.mp4', '2.mp4', '11.mp4', '14.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['6.mp4', '4.mp4', '2.mp4', '11.mp4', '14.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['2.mp4', '12.mp4', '9.mp4', '10.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['2.mp4', '12.mp4', '9.mp4', '10.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['14.mp4', '6.mp4', '15.mp4', '10.mp4', '3.mp4', '1.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['14.mp4', '6.mp4', '15.mp4', '10.mp4', '3.mp4', '1.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['8.mp4', '5.mp4', '9.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['8.mp4', '5.mp4', '9.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['1.mp4', '2.mp4', '8.mp4', '9.mp4', '12.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['1.mp4', '2.mp4', '8.mp4', '9.mp4', '12.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['5.mp4', '11.mp4', '2.mp4', '3.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['5.mp4', '11.mp4', '2.mp4', '3.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['18.mp4', '13.mp4', '3.mp4', '2.mp4', '4.mp4', '12.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['18.mp4', '13.mp4', '3.mp4', '2.mp4', '4.mp4', '12.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['5.mp4', '13.mp4', '10.mp4', '11.mp4', '3.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['5.mp4', '13.mp4', '10.mp4', '11.mp4', '3.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/environment/Dockerfile
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4
+# (concat of the correct picks in slot order). Failure-loud — no
+# stderr suppression, no check=False.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['8.mp4', '10.mp4', '7.mp4', '6.mp4', '11.mp4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / c) for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,22 @@ list_file.write_text(
     "\n".join(f"file '{materials / c}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+# Try stream-copy concat first (fastest, identical pixels). If clips
+# differ in codec/params, fall back to a re-encode that the SSIM gate
+# tolerates (≥0.98 on honest re-encode).
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/steps/solve/tests/judge.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_assembly solution. Ports the per-slot exact-pick
-verifier from video-agent-runner/verifiers/video_assembly/runner.py
-(no S3, stdlib only).
+"""Score one agentic_vbench_assembly solution: per-slot pick + SSIM honesty.
 
-Reward = fraction of slots whose `source` matches the baked-in CORRECT_PICKS,
-in slot order.
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_PICKS[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
+
 CORRECT_PICKS = ['8.mp4', '10.mp4', '7.mp4', '6.mp4', '11.mp4']
+
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
 def _normalize(src) -> str:
@@ -24,24 +43,134 @@ def _normalize(src) -> str:
     return s
 
 
-def _zero(reason):
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
+
+
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
+
+
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
             "n_slots": len(CORRECT_PICKS),
             "n_correct": 0,
-            "pred": [],
+            "n_honest_correct": 0,
+            "pred": pred or [],
             "correct": CORRECT_PICKS,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -52,31 +181,76 @@ def score(solution_path):
     pred = [_normalize(seg.get("source", "")) for seg in segments]
     n = len(CORRECT_PICKS)
     if len(pred) != n:
-        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}")
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
 
-    correct_count = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
-    reward = correct_count / n
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_PICKS[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_PICKS,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_PICKS[i]}
+        if pred[i] != CORRECT_PICKS[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / pred[i]
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": reward,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
             "n_slots": n,
-            "n_correct": correct_count,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_PICKS,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/steps/solve/tests/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verifier: scores /workspace/output/solution.json against the inline
-# CORRECT_PICKS baked into judge.py. Writes 0–1 reward to
-# /logs/verifier/reward.json (and reward.txt for legacy readers).
+# Verifier: per-slot scoring with SSIM-honesty gate. Judges both
+# /workspace/output/solution.json (slot picks) AND
+# /workspace/output/solution.mp4 (actual concatenated video) against
+# the materials in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
@@ -12,5 +13,7 @@ fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['3', '5', '7', '11', '9', '4', '10', '13', '12', '2', '6', '8', '1']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['3', '5', '7', '11', '9', '4', '10', '13', '12', '2', '6', '8', '1']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['6', '9', '10', '12', '8', '11', '4', '1', '3', '7', '13', '2', '5']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['6', '9', '10', '12', '8', '11', '4', '1', '3', '7', '13', '2', '5']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['13', '5', '8', '7', '10', '3', '11', '14', '6', '15', '9', '1', '4', '2', '12']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['13', '5', '8', '7', '10', '3', '11', '14', '6', '15', '9', '1', '4', '2', '12']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['7', '9', '5', '2', '11', '10', '1', '6', '3', '8', '4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['7', '9', '5', '2', '11', '10', '1', '6', '3', '8', '4']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['19', '20', '15', '18', '1', '3', '5', '10', '7', '14', '17', '8', '4', '11', '13', '9', '2', '12', '6', '16']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['19', '20', '15', '18', '1', '3', '5', '10', '7', '14', '17', '8', '4', '11', '13', '9', '2', '12', '6', '16']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['3', '5', '10', '6', '7', '8', '9', '1', '4', '2']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['3', '5', '10', '6', '7', '8', '9', '1', '4', '2']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['11', '12', '8', '14', '7', '9', '15', '6', '2', '17', '16', '1', '10', '5', '4', '3', '13']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['11', '12', '8', '14', '7', '9', '15', '6', '2', '17', '16', '1', '10', '5', '4', '3', '13']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['14', '10', '7', '11', '13', '12', '3', '1', '15', '18', '9', '16', '8', '2', '17', '6', '4', '5']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['14', '10', '7', '11', '13', '12', '3', '1', '15', '18', '9', '16', '8', '2', '17', '6', '4', '5']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['9', '7', '10', '12', '8', '11', '3', '5', '4', '1', '2', '6']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['9', '7', '10', '12', '8', '11', '3', '5', '4', '1', '2', '6']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['4', '7', '6', '2', '9', '13', '5', '12', '1', '3', '8', '10', '11']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['4', '7', '6', '2', '9', '13', '5', '12', '1', '3', '8', '10', '11']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['5', '9', '1', '7', '2', '8', '4', '6', '3']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['5', '9', '1', '7', '2', '8', '4', '6', '3']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['4', '6', '5', '7', '2', '3', '1']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['4', '6', '5', '7', '2', '3', '1']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['13', '11', '6', '10', '12', '2', '4', '3', '1', '5', '7', '8', '9']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['13', '11', '6', '10', '12', '2', '4', '3', '1', '5', '7', '8', '9']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['5', '9', '8', '11', '12', '1', '2', '6', '3', '7', '4', '10']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['5', '9', '8', '11', '12', '1', '2', '6', '3', '7', '4', '10']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['15', '11', '17', '7', '1', '10', '4', '16', '12', '2', '5', '9', '18', '6', '3', '8', '14', '13']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['15', '11', '17', '7', '1', '10', '4', '16', '12', '2', '5', '9', '18', '6', '3', '8', '14', '13']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['10', '7', '11', '6', '8', '13', '1', '4', '9', '2', '5', '3', '12']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['10', '7', '11', '6', '8', '13', '1', '4', '9', '2', '5', '3', '12']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['6', '12', '3', '13', '2', '4', '9', '11', '1', '8', '10', '7', '5']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['6', '12', '3', '13', '2', '4', '9', '11', '1', '8', '10', '7', '5']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['5', '1', '9', '4', '10', '2', '11', '7', '8', '3', '6', '12']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['5', '1', '9', '4', '10', '2', '11', '7', '8', '3', '6', '12']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['8', '3', '7', '9', '1', '2', '4', '5', '6']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['8', '3', '7', '9', '1', '2', '4', '5', '6']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['2', '8', '5', '6', '10', '4', '3', '7', '9', '1']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['2', '8', '5', '6', '10', '4', '3', '7', '9', '1']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['2', '6', '11', '8', '14', '12', '3', '7', '9', '4', '5', '1', '10', '13', '15']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['2', '6', '11', '8', '14', '12', '3', '7', '9', '4', '5', '1', '10', '13', '15']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task29/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task29/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task29/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task29/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['3', '7', '11', '8', '5', '10', '6', '12', '2', '9', '4', '1']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task29/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task29/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['3', '7', '11', '8', '5', '10', '6', '12', '2', '9', '4', '1']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task29/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task29/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['10', '7', '6', '8', '2', '9', '4', '1', '5', '3']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['10', '7', '6', '8', '2', '9', '4', '1', '5', '3']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task30/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task30/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task30/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task30/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['4', '9', '8', '3', '6', '11', '10', '1', '2', '5', '7']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task30/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task30/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['4', '9', '8', '3', '6', '11', '10', '1', '2', '5', '7']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task30/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task30/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task31/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task31/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task31/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task31/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['3', '1', '9', '6', '5', '10', '2', '8', '4', '7']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task31/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task31/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['3', '1', '9', '6', '5', '10', '2', '8', '4', '7']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task31/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task31/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['6', '8', '16', '15', '7', '3', '14', '13', '11', '5', '2', '9', '1', '10', '4', '12']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['6', '8', '16', '15', '7', '3', '14', '13', '11', '5', '2', '9', '1', '10', '4', '12']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['6', '5', '7', '8', '1', '9', '10', '3', '2', '4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['6', '5', '7', '8', '1', '9', '10', '3', '2', '4']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['15', '11', '1', '10', '9', '2', '14', '16', '12', '3', '4', '8', '7', '6', '13', '5']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['15', '11', '1', '10', '9', '2', '14', '16', '12', '3', '4', '8', '7', '6', '13', '5']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['4', '12', '8', '19', '9', '13', '1', '6', '5', '17', '3', '14', '10', '16', '18', '7', '2', '15', '11']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['4', '12', '8', '19', '9', '13', '1', '6', '5', '17', '3', '14', '10', '16', '18', '7', '2', '15', '11']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['19', '8', '15', '16', '11', '12', '17', '3', '14', '5', '13', '2', '18', '9', '1', '10', '6', '7', '4']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['19', '8', '15', '16', '11', '12', '17', '3', '14', '5', '13', '2', '18', '9', '1', '10', '6', '7', '4']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/environment/Dockerfile
@@ -5,7 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         ca-certificates \
+        libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Verifier deps: SSIM-honesty gate uses opencv + numpy to read sampled
+# frames from solution.mp4 and the candidate clips.
+RUN pip install --no-cache-dir \
+        "numpy<3" "opencv-python-headless==4.13.*"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/steps/solve/solution/solve.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Oracle: writes the ground-truth solution.json directly.
+# Oracle: writes the ground-truth solution.json AND solution.mp4 (concat
+# of the correct narrative order). Failure-loud: re-encode fallback if
+# stream-copy concat fails on codec-mismatched clips.
 set -euo pipefail
 
-mkdir -p /workspace/output
+mkdir -p /workspace/output /workspace/work
 
 python3 - <<'PY'
-import json, subprocess
+import json, subprocess, sys
 from pathlib import Path
 
 CORRECT = ['18', '14', '1', '8', '17', '15', '13', '12', '2', '3', '6', '5', '16', '7', '9', '4', '11', '10']
@@ -19,7 +21,6 @@ def duration(p):
     return float(out)
 
 durs = {c: duration(materials / f"{c}.mp4") for c in CORRECT}
-
 t = 0.0
 segments = []
 for c in CORRECT:
@@ -41,10 +42,19 @@ list_file.write_text(
     "\n".join(f"file '{materials / f'{c}.mp4'}'" for c in CORRECT) + "\n"
 )
 
-subprocess.run([
-    "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_file),
-    "-c", "copy", "/workspace/output/solution.mp4",
-], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+copy_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+            "-i", str(list_file), "-c", "copy",
+            "/workspace/output/solution.mp4"]
+r = subprocess.run(copy_cmd, capture_output=True)
+if r.returncode != 0:
+    print("stream-copy concat failed, falling back to re-encode", file=sys.stderr)
+    print(r.stderr.decode()[-400:], file=sys.stderr)
+    reenc_cmd = ["ffmpeg", "-y", "-f", "concat", "-safe", "0",
+                 "-i", str(list_file),
+                 "-c:v", "libx264", "-preset", "veryfast", "-crf", "18",
+                 "-c:a", "aac", "-b:a", "192k",
+                 "/workspace/output/solution.mp4"]
+    subprocess.run(reenc_cmd, check=True)
 PY
 
-echo "oracle: wrote /workspace/output/solution.json and (best-effort) solution.mp4"
+echo "oracle: wrote /workspace/output/solution.json + solution.mp4"

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/steps/solve/tests/judge.py
@@ -1,74 +1,168 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution. Same composite as
-video-agent-runner/verifiers/video_order/runner.py (no S3, stdlib only).
+"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
 
-Composite reward = 0.4*(1-nd) + 0.3*lis + 0.3*adj in [0,1].
+Per-slot score:
+  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
+             = 0 otherwise
+
+SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
+output range in solution.mp4, sample the matching offsets from the
+claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
+(same threshold the repair-task preservation gates use — robust to
+re-encoding noise, fails on real mismatch).
+
+Reward = (# slots that pass both gates) / n_slots.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
-from bisect import bisect_left
 from pathlib import Path
+
+os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
+os.environ.setdefault("OPENCV_VIDEOIO_PRIORITY_FFMPEG", "100")
+
+import cv2
+import numpy as np
+
+cv2.setNumThreads(1)
 
 CORRECT_ORDER = ['18', '14', '1', '8', '17', '15', '13', '12', '2', '3', '6', '5', '16', '7', '9', '4', '11', '10']
 
-
-def metric_nd(pred, correct):
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    correct_pos = {c: i for i, c in enumerate(correct)}
-    n = len(correct)
-    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
-    max_total = (n * n) // 2
-    return total / max_total if max_total else 0.0
+SSIM_THRESHOLD = 0.95
+N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
 
 
-def metric_lis(pred, correct):
-    rank = {c: i for i, c in enumerate(correct)}
-    seq = [rank[c] for c in pred if c in rank]
-    if not seq:
-        return 0.0
-    tails = []
-    for x in seq:
-        i = bisect_left(tails, x)
-        if i == len(tails):
-            tails.append(x)
-        else:
-            tails[i] = x
-    return len(tails) / len(pred)
+SSIM_MAX_SIDE = 360  # downscale frames before SSIM — 4K SSIM at full
+                     # res is prohibitively slow (~25× window search × 3 samples × N slots
+                     # blows the verifier timeout). 360p preserves structure for the
+                     # identity/diff discrimination this gate is doing.
 
 
-def metric_adj(pred, correct):
-    if len(correct) <= 1:
-        return 1.0
-    pred_pos = {c: i for i, c in enumerate(pred)}
-    caught = 0
-    for i in range(len(correct) - 1):
-        a, b = correct[i], correct[i + 1]
-        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
-            caught += 1
-    return caught / (len(correct) - 1)
+def _downscale_max(frame: np.ndarray, max_side: int = SSIM_MAX_SIDE) -> np.ndarray:
+    h, w = frame.shape[:2]
+    m = max(h, w)
+    if m <= max_side:
+        return frame
+    scale = max_side / m
+    return cv2.resize(frame, (int(round(w * scale)), int(round(h * scale))),
+                      interpolation=cv2.INTER_AREA)
 
 
-def _zero(reason):
+def _ssim_gray(a_bgr: np.ndarray, b_bgr: np.ndarray) -> float:
+    """Mean SSIM on grayscale frames. 11×11 Gaussian kernel, σ=1.5.
+    Robust to encoder noise (≥0.98 on clean re-encode); drops below 0.95
+    on real pixel mismatch (different content, filter, scaling)."""
+    if a_bgr.shape != b_bgr.shape:
+        b_bgr = cv2.resize(b_bgr, (a_bgr.shape[1], a_bgr.shape[0]),
+                           interpolation=cv2.INTER_AREA)
+    a = cv2.cvtColor(a_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    b = cv2.cvtColor(b_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+    mu_a = cv2.GaussianBlur(a, (11, 11), 1.5)
+    mu_b = cv2.GaussianBlur(b, (11, 11), 1.5)
+    mu_a_sq, mu_b_sq, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    s_a = cv2.GaussianBlur(a * a, (11, 11), 1.5) - mu_a_sq
+    s_b = cv2.GaussianBlur(b * b, (11, 11), 1.5) - mu_b_sq
+    s_ab = cv2.GaussianBlur(a * b, (11, 11), 1.5) - mu_ab
+    num = (2 * mu_ab + C1) * (2 * s_ab + C2)
+    den = (mu_a_sq + mu_b_sq + C1) * (s_a + s_b + C2)
+    return float(np.mean(num / den))
+
+
+def _read_frames_around(path: Path, t_s: float, n: int = 5,
+                       pre_offset_s: float = 0.10):
+    """Seek to t_s − pre_offset_s and read up to `n` consecutive frames.
+    Returns a list of BGR ndarrays (may be shorter than n at end of video).
+    Used to absorb cv2 keyframe-seek imprecision — codec seeks land at
+    the nearest keyframe and decode forward, so a single read at a target
+    time can be off by 1-3 frames. Comparing a small frame window pair-wise
+    finds the matching alignment."""
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return []
+    cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, (t_s - pre_offset_s) * 1000.0))
+    out = []
+    for _ in range(n):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        out.append(_downscale_max(frame))
+    cap.release()
+    return out
+
+
+def _max_ssim_pair(frames_a, frames_b) -> float:
+    best = 0.0
+    for fa in frames_a:
+        for fb in frames_b:
+            s = _ssim_gray(fa, fb)
+            if s > best:
+                best = s
+    return best
+
+
+def _check_honesty(solution_mp4: Path, source_mp4: Path,
+                   segment: dict) -> tuple[bool, list]:
+    """Sample N frames across the segment's output range and matching
+    positions in the source clip's source_range. Returns (pass, details)."""
+    try:
+        out_lo, out_hi = float(segment["output"][0]), float(segment["output"][1])
+        src_lo, src_hi = float(segment["source_range"][0]), float(segment["source_range"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, [{"reason": "malformed segment ranges"}]
+    dur_out = out_hi - out_lo
+    dur_src = src_hi - src_lo
+    if dur_out <= 0 or dur_src <= 0:
+        return False, [{"reason": f"non-positive duration out={dur_out} src={dur_src}"}]
+    samples = []
+    # Sample at internal positions only: 1/(N+1), 2/(N+1), ..., N/(N+1).
+    # Avoids both range endpoints; cv2 seek can land off-by-one at exact
+    # boundaries on some codecs.
+    for k_i in range(1, N_SAMPLES + 1):
+        k = k_i / (N_SAMPLES + 1)
+        t_out = out_lo + k * dur_out
+        t_src = src_lo + k * dur_src
+        # Read a small frame window from each video to absorb seek
+        # imprecision; pair-wise max SSIM finds the matching alignment.
+        f_out_list = _read_frames_around(solution_mp4, t_out)
+        f_src_list = _read_frames_around(source_mp4, t_src)
+        if not f_out_list or not f_src_list:
+            samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                            "t_src_s": round(t_src, 3), "ssim": None,
+                            "reason": "frame read failed"})
+            return False, samples
+        ssim = _max_ssim_pair(f_out_list, f_src_list)
+        samples.append({"k": round(k, 3), "t_out_s": round(t_out, 3),
+                        "t_src_s": round(t_src, 3), "ssim": round(ssim, 4),
+                        "window": f"{len(f_out_list)}x{len(f_src_list)}"})
+        if ssim < SSIM_THRESHOLD:
+            return False, samples
+    return True, samples
+
+
+def _zero(reason, pred=None):
     return {
         "reward": 0.0,
         "details": {
             "reason": reason,
-            "nd_score": 0.0,
-            "lis_score": 0.0,
-            "adj_score": 0.0,
-            "strict_match": 0.0,
+            "n_slots": len(CORRECT_ORDER),
+            "n_correct": 0,
+            "n_honest_correct": 0,
+            "pred": pred or [],
+            "correct": CORRECT_ORDER,
         },
     }
 
 
-def score(solution_path):
-    if not solution_path.exists():
-        return _zero(f"solution.json not found at {solution_path}")
+def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    if not solution_json.exists():
+        return _zero(f"solution.json not found at {solution_json}")
     try:
-        sol = json.loads(solution_path.read_text())
+        sol = json.loads(solution_json.read_text())
     except json.JSONDecodeError as e:
         return _zero(f"solution.json invalid JSON: {e}")
 
@@ -77,40 +171,84 @@ def score(solution_path):
         return _zero("solution.json: segments not a list")
 
     pred = [str(seg.get("source", "")) for seg in segments]
+    n = len(CORRECT_ORDER)
+    if len(pred) != n:
+        return _zero(f"slot count mismatch: expected {n}, got {len(pred)}", pred=pred)
+
     if sorted(pred) != sorted(CORRECT_ORDER):
         return _zero(
-            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}"
+            f"slot set mismatch: expected {sorted(CORRECT_ORDER)}, got {sorted(pred)}",
+            pred=pred,
         )
 
-    nd = metric_nd(pred, CORRECT_ORDER)
-    lis = metric_lis(pred, CORRECT_ORDER)
-    adj = metric_adj(pred, CORRECT_ORDER)
-    strict = 1.0 if pred == CORRECT_ORDER else 0.0
-    nd_score = 1.0 - nd
-    final = 0.4 * nd_score + 0.3 * lis + 0.3 * adj
+    n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
+
+    if not solution_mp4.exists():
+        return {
+            "reward": 0.0,
+            "details": {
+                "reason": f"solution.mp4 not found at {solution_mp4}",
+                "n_slots": n,
+                "n_correct": n_correct,
+                "n_honest_correct": 0,
+                "pred": pred,
+                "correct": CORRECT_ORDER,
+            },
+        }
+
+    per_slot = []
+    n_honest_correct = 0
+    for i in range(n):
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
+        if pred[i] != CORRECT_ORDER[i]:
+            slot["match"] = False
+            slot["honest"] = None  # not checked
+            slot["score"] = 0
+        else:
+            slot["match"] = True
+            source_path = materials_dir / f"{pred[i]}.mp4"
+            if not source_path.exists():
+                slot["honest"] = False
+                slot["honesty_reason"] = f"missing source clip {source_path}"
+                slot["score"] = 0
+            else:
+                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+                slot["honest"] = honest
+                slot["samples"] = samples
+                slot["score"] = 1 if honest else 0
+                if honest:
+                    n_honest_correct += 1
+        per_slot.append(slot)
 
     return {
-        "reward": final,
+        "reward": n_honest_correct / n,
         "details": {
             "reason": "ok",
-            "nd_score": nd_score,
-            "lis_score": lis,
-            "adj_score": adj,
-            "strict_match": strict,
+            "n_slots": n,
+            "n_correct": n_correct,
+            "n_honest_correct": n_honest_correct,
+            "ssim_threshold": SSIM_THRESHOLD,
+            "n_samples_per_segment": N_SAMPLES,
             "pred": pred,
             "correct": CORRECT_ORDER,
+            "per_slot": per_slot,
         },
     }
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path,
+                        help="path to solution.json")
+    parser.add_argument("--solution-mp4", required=True, type=Path,
+                        help="path to solution.mp4")
+    parser.add_argument("--materials-dir", required=True, type=Path,
+                        help="dir containing the candidate clips (1.mp4 ... N.mp4)")
     parser.add_argument("--reward-json", required=True, type=Path)
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution)
+    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/steps/solve/tests/test.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+# Verifier: per-slot scoring with SSIM-honesty gate. Reads both
+# /workspace/output/solution.json AND /workspace/output/solution.mp4
+# and validates against the candidate clips in /workspace/materials/.
 set -euo pipefail
 
 mkdir -p /logs/verifier /logs/artifacts
-
 if [ -d /workspace/output ]; then
     cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
 fi
 
 python3 /tests/judge.py \
         --solution /workspace/output/solution.json \
+        --solution-mp4 /workspace/output/solution.mp4 \
+        --materials-dir /workspace/materials \
         --reward-json /logs/verifier/reward.json \
         --reward-txt /logs/verifier/reward.txt


### PR DESCRIPTION
## Summary

Before this change, the assembly and sequencing verifiers checked `solution.json` only — `solution.mp4` was completely ignored. The instruction promised "the verifier checks the manifest against the actual video content, so misreporting will fail" but that was never enforced; an agent could score 1.0 by writing a correct JSON and skipping the mp4 concat entirely.

The new judges check both. Per slot:

```
slot_score = 1 iff (pred[i] == CORRECT[i])
            AND  SSIM-honesty check passes for that segment
           = 0 otherwise

reward = sum(slot_score) / n_slots
```

## SSIM-honesty check

For each `{output:[t0,t1], source:"X", source_range:[s0,s1]}` segment, sample 3 frames at 25/50/75% through both ranges:

- `solution.mp4` at `t0 + k·(t1−t0)`
- `materials/X.mp4` at `s0 + k·(s1−s0)`

Compare with SSIM (gray-domain, 11×11 Gaussian kernel — same as the repair preservation gates). Require **SSIM ≥ 0.95 on every pair** — robust to re-encode noise, fails on real content mismatch.

Three engineering details:

- **Frame-window search (5×5).** cv2 keyframe-seek lands within 1-3 frames of the target time, and consecutive frames can drift SSIM to 0.92-0.94 even on identical content. Reading 5 frames after a seek-back-by-100ms in both videos and taking the max pair-wise SSIM finds the matching alignment and lifts the score back to 1.0.
- **360p downscale before SSIM.** 4K source material blows the verifier timeout (25 SSIMs × 3 samples × 10+ slots at full res ≫ 600s). Downscaling preserves SSIM's structural information; identity → 1.0, wrong content → ≪ 0.95.
- **Oracle `solve.sh` hardened.** Drops `check=False` and stderr suppression on the ffmpeg concat; falls back to a re-encode if `-c copy` rejects a codec-mismatched clip pair.

`Dockerfile` gains `numpy<3` + `opencv-python-headless==4.13.*` (same pin the repair judges use).

## Test plan

- [x] **49 oracle trials on Modal** — every one hits reward `1.000`. Slowest: sequencing-task15 / task22 at 6m, well within the 10-min verifier timeout.
- [x] **Honest pilot (assembly-task1 + sequencing-task1)**: correct JSON + correct mp4 → 1.0.
- [x] **Negative pilots**: correct JSON + no mp4 → 0.0; correct JSON + wrong-content mp4 → 0.0. Both families.
- [x] **Local syntax check**: all 49 judges `py_compile` clean.

## Files

196 files: 49 × {`judge.py`, `test.sh`, `solve.sh`, `Dockerfile`} across 18 assembly + 31 sequencing tasks. Lines: +11,105 / −2,679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)