### PR TITLE
fix: cap task storage_mb at 8 GB to fit Daytona's per-sandbox limit

### DIFF
--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=1)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=10)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=11)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=12)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=13)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=14)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=15)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=16)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=17)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=18)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=2)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=3)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=4)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=5)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=6)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=7)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=8)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/task.toml
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_assembly (row task_id=9)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_repair/exp-codec-restore-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-codec-restore-task01/task.toml
@@ -14,7 +14,7 @@ corruption = "ffmpeg roundtrip: pcm_s16le -> libopus @ 12kbps -> pcm_s16le (seed
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [[steps]]

--- a/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/task.toml
@@ -16,7 +16,7 @@ attribution = "see source URL"
 build_timeout_sec = 1800.0
 cpus = 4
 memory_mb = 8192
-storage_mb = 16384
+storage_mb = 8192
 allow_internet = true
 
 [[steps]]

--- a/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/task.toml
@@ -16,7 +16,7 @@ attribution = "see source URL"
 build_timeout_sec = 1800.0
 cpus = 4
 memory_mb = 8192
-storage_mb = 16384
+storage_mb = 8192
 allow_internet = true
 
 [[steps]]

--- a/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/task.toml
@@ -16,7 +16,7 @@ attribution = "see source URL"
 build_timeout_sec = 1800.0
 cpus = 4
 memory_mb = 8192
-storage_mb = 16384
+storage_mb = 8192
 allow_internet = true
 
 [[steps]]

--- a/tasks/agentic_vbench_repair/exp-declip-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-declip-task01/task.toml
@@ -14,7 +14,7 @@ corruption = "hard clip np.clip(±q) at q=0.9-quantile of |x|, threshold=0.3311,
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [[steps]]

--- a/tasks/agentic_vbench_repair/exp-dereverb-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-dereverb-task01/task.toml
@@ -14,7 +14,7 @@ corruption = "shoebox RIR convolve, target_rt60=0.687 s, abs=0.1564, max_order=9
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [[steps]]

--- a/tasks/agentic_vbench_repair/exp-dns-denoise-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-dns-denoise-task01/task.toml
@@ -14,7 +14,7 @@ corruption = "additive DNS noise at SNR=4.36 dB (seed=42)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [[steps]]

--- a/tasks/agentic_vbench_repair/exp-voicebank-denoise-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-voicebank-denoise-task01/task.toml
@@ -14,7 +14,7 @@ corruption = "additive DEMAND-derived noise at SNR=10 dB (seed=42)"
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [[steps]]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=1, upstream=task5_5: 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=10, upstream=task5_5:
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=11, upstream=task5_5:
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=12, upstream=task5_5:
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=13, upstream=task5_5:
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=14, upstream=task5_5:
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=15, upstream=task5_5:
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=16, upstream=task5_5:
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=17, upstream=task5_5:
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=18, upstream=task5_5:
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=19, upstream=task5_5:
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=2, upstream=task5_5: 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=20, upstream=task5_5:
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=21, upstream=task5_5:
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=22, upstream=task5_5:
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=23, upstream=task5_4 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=24, upstream=task5_4 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=25, upstream=task5_4 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=26, upstream=task5_4 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=27, upstream=task5_4 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=28, upstream=task5_4 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task29/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task29/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=29, upstream=task5_4 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=3, upstream=task5_5: 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task30/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task30/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=30, upstream=task5_4 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task31/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task31/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=31, upstream=task5_4 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=4, upstream=task5_5: 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=5, upstream=task5_5: 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=6, upstream=task5_5: 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=7, upstream=task5_5: 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=8, upstream=task5_5: 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/task.toml
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/task.toml
@@ -13,7 +13,7 @@ source = "ameddserM/agentic_vbench_sequencing (row task_id=9, upstream=task5_5: 
 build_timeout_sec = 600.0
 cpus = 2
 memory_mb = 4096
-storage_mb = 10240
+storage_mb = 8192
 allow_internet = true
 
 [environment.env]


### PR DESCRIPTION
## Summary
- Lower `storage_mb` from 16384/10240 → 8192 across all 57 affected `task.toml`s (every task now declares 8 GB).
- Unblocks Daytona executor: oracle smoke now passes on all three families (repair, assembly, sequencing).

## Why
Old values were inherited from the trial-time-fetch era. With PR #10 (Docker bake), the real disk footprint per trial is ~1–2 GB (base image + ≤100 MB materials + workdir scratch); 8 GB still leaves 4–8× headroom. Daytona caps disk at 10 GB per sandbox, so the 16 GB and 10 GB values were getting rejected at sandbox-creation time. Modal and local Docker were unaffected.

## Verification
Three oracle smokes on Daytona (one per family, all reward 1.0):

| Family | Task | Reward | Time |
|---|---|---|---|
| repair | `exp-color-shot-gobelins-task01` | 1.000 | 2m 11s |
| assembly | `agentic-vbench-assembly-task1` | 1.000 | 43s |
| sequencing | `agentic-vbench-sequencing-task1` | 1.000 | 3m 12s |

## Test plan
- [x] Daytona oracle smoke across all 3 families → 1.000
- [x] Diff is uniform (every change is the same single line)