### PR TITLE
docs: trim README to a user-facing surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,106 +1,81 @@
 # agentic-vbench
 
-A benchmark suite for evaluating AI coding agents on three families of
-video/audio editing tasks, built on top of
-[Harbor](https://www.harborframework.com/). Each task is a single Harbor
-task directory — Harbor handles agent installation, sandbox orchestration on
-Modal, concurrency, trial lifecycle, and result collection. This repo ships
-the tasks themselves plus a thin wrapper for running and scoring them.
+A benchmark suite for evaluating AI coding agents on **video and audio editing tasks**. Built on top of [Harbor](https://www.harborframework.com/) — agent installation, sandboxed execution, concurrency, and trial scoring are handled for you.
 
-## What's in the suite
+Three task families, **69 tasks total**, every task scored deterministically on a 0–1 scale.
+
+---
+
+## 📊 What's in the suite
 
 | Family | Count | What the agent does |
 |---|---:|---|
-| `agentic_vbench_repair` | 20 | Restore a single localised corruption (color, blur, super-res, swap, glitch, cut, disfluency, or audio defect) inside a clip. |
-| `agentic_vbench_assembly` | 18 | Assemble 4 candidate clips into the correct slot order to satisfy a prompt. |
-| `agentic_vbench_sequencing` | 31 | Re-order shuffled clips into the correct narrative sequence. |
+| `agentic_vbench_repair` | 20 | Restore a localized corruption (color shift, blur, low-res, swapped object, glitch, content cut, disfluency, or audio defect) in a clip. |
+| `agentic_vbench_assembly` | 18 | Pick 4 candidate clips from a pool and place them in the correct slot order to satisfy a prompt. |
+| `agentic_vbench_sequencing` | 31 | Re-order a set of shuffled clips into the correct narrative sequence. |
 
-Per-task materials (input clips for the agent, reference goldens for the
-verifier) live on HuggingFace under `ameddserM/agentic_vbench_*` and are
-fetched at trial start by the task's `workdir/setup.sh`. The verifier is
-baked into each task's `tests/judge.py` at build time and runs at trial
-end — Harbor writes the per-trial reward to `/logs/verifier/reward.json`.
+Every task ships a bundled **golden solution** and a **broken/random baseline** — by construction the golden scores 1.0 and the baseline scores 0.0. See [`docs/VERIFIER_DESIGN.md`](docs/VERIFIER_DESIGN.md) for the per-family scoring math.
 
-## How repair tasks are scored
+---
 
-For repair tasks, every metric is normalized so that the broken input scores
-0 and the bundled golden scores 1 by construction:
+## 🚀 Quick start
 
-- higher-is-better: `score = clip((M_out − M_broken) / (M_golden − M_broken), 0, 1)`
-- lower-is-better: `score = clip((M_broken − M_out) / (M_broken − M_golden), 0, 1)`
-
-Per-family metrics: PESQ-WB (denoise), SRMR (dereverb), SI-SDR (declip), LSD
-(codec), CIEDE2000 (color), LPIPS (deblur, swap), LPIPS+Y-PSNR composite
-(super-res), binary range-F1 + SSIM honesty gate (cut / glitch / disfluency).
-
-Full math + per-family details: [`docs/VERIFIER_DESIGN.md`](docs/VERIFIER_DESIGN.md).
-
-Assembly and sequencing tasks score deterministically off the agent's
-reported ordering — assembly uses exact-slot accuracy with `.mp4`
-normalization; sequencing uses a composite
-`0.4·(1 − normalized_footrule) + 0.3·LIS_ratio + 0.3·adjacency`.
-
-## Quick start
+### Install
 
 ```bash
-# 1. Install Harbor (pinned)
+git clone https://github.com/PhiloLabs/agentic-vbench.git
+cd agentic-vbench
 ./scripts/install-harbor.sh
+python3 -m venv .venv && .venv/bin/pip install --upgrade pip
+```
 
-# 2. Local Python env (only needed for the rollout wrapper)
-python3 -m venv .venv
-.venv/bin/pip install --upgrade pip
+### Sanity check (Docker + oracle agent → reward ≈ 1.0)
 
-# 3. Run one task locally on Docker, oracle mode (sanity check — expect reward ≈ 1.0)
+```bash
 harbor run -p tasks/agentic_vbench_repair/exp-codec-restore-task01 \
            -e docker -a oracle
+```
 
-# 4. Run the full suite on Modal with claude-code as the agent
+### Run the full suite (Modal + claude-code agent)
+
+```bash
 export ANTHROPIC_API_KEY=...
 export MODAL_TOKEN_ID=... MODAL_TOKEN_SECRET=...
 
 .venv/bin/python scripts/parallel_rollout.py \
     --mode claude --env modal --max-parallel 20 \
     --tasks $(ls tasks/agentic_vbench_repair/ | tr '\n' ' ')
-
-# Same pattern for the other two families:
-.venv/bin/python scripts/parallel_rollout.py \
-    --mode claude --env modal --max-parallel 20 \
-    --tasks $(ls tasks/agentic_vbench_assembly/ | tr '\n' ' ')
 ```
 
-Rewards land in `logs/rollout-results.tsv` (one row per task) and in each
-trial's `jobs/<job-name>/<trial>/verifier/reward.json`.
+Same pattern for `tasks/agentic_vbench_assembly/` and `tasks/agentic_vbench_sequencing/`. Per-task rewards land in `logs/rollout-results.tsv`.
 
-## Repo layout
+---
+
+## ⚙️ Supported executors
+
+| Executor | Use when | Required env |
+|---|---|---|
+| `docker` | Local sanity checks, single-task debugging | none |
+| `modal` | Large parallel runs across the suite | `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET` |
+| `daytona` | Cloud sandboxes (alternative to Modal) | `DAYTONA_API_KEY` |
+
+All task materials are hosted on Hugging Face under [`ameddserM/agentic_vbench_video_*`](https://huggingface.co/ameddserM) and baked into each task's Docker image at build time, so the same image runs on any executor without provider-specific configuration.
+
+---
+
+## 📁 Repo layout
 
 ```
 agentic-vbench/
-├── AGENTS.md / CLAUDE.md             # repo policy
-├── README.md, LICENSE
-├── tasks/
-│   ├── agentic_vbench_repair/        # 20 repair tasks
-│   ├── agentic_vbench_assembly/      # 18 assembly tasks
-│   └── agentic_vbench_sequencing/    # 31 sequencing tasks
-├── scripts/                          # Harbor wrapper (no task generation)
-│   ├── install-harbor.sh
-│   ├── parallel_rollout.py           # run + collect rewards across tasks
-│   ├── monitor_job.py                # tail a running trial
-│   └── _task_paths.py                # task-name → path resolver
-├── docs/VERIFIER_DESIGN.md           # verifier math (repair tasks)
-└── jobs/, logs/, site/               # runtime outputs (gitignored)
+├── tasks/                              # 69 Harbor task directories
+│   ├── agentic_vbench_repair/          # 20 repair tasks
+│   ├── agentic_vbench_assembly/        # 18 assembly tasks
+│   └── agentic_vbench_sequencing/      # 31 sequencing tasks
+├── scripts/
+│   ├── install-harbor.sh               # Harbor CLI pin
+│   ├── parallel_rollout.py             # batched rollout + reward collection
+│   ├── monitor_job.py                  # tail a running trial
+│   └── _task_paths.py                  # task-name → path resolver
+├── docs/VERIFIER_DESIGN.md             # per-family scoring math
+└── README.md, LICENSE, AGENTS.md
 ```
-
-## How a task runs
-
-Each task is a Harbor multi-step dir with a single `solve` step. At trial
-start, Harbor runs `steps/solve/workdir/setup.sh`, which `curl`s the
-per-task materials zip from HuggingFace and unpacks the agent-facing
-`input/` files into `/workspace/materials/`. The agent then writes its
-output to `/workspace/output/`. Harbor then runs `tests/test.sh`, which
-fetches the verifier-only `golden/` files (kept separate from the agent's
-view) and invokes the baked-in `judge.py` to produce
-`/logs/verifier/reward.json`.
-
-Oracles ship a `solution/solve.sh` that fetches the golden materials and
-writes them to `/workspace/output/` directly; running with `-a oracle`
-should yield reward ≈ 1.0 on every task.


### PR DESCRIPTION
**Not for merge yet — opened so the rendered diff is easy to review.**

## Summary
- Drop the "How repair tasks are scored" section — repair isn't special; all three families normalize to 0–1 against a bundled golden, so one sentence + a link to `docs/VERIFIER_DESIGN.md` is enough.
- Drop the "How a task runs" section and references to `setup.sh` / `tests/judge.py` / `/logs/verifier/reward.json` (dev internals; not useful to a user running the benchmark).
- Add a **Supported executors** table to surface that Docker, Modal, and Daytona all work against the same baked Docker image.
- Tighten Quick Start to one walking path: install → oracle sanity check on Docker → full-suite rollout on Modal.

Demo GIFs / screenshots to be added later.

## Preview
- Branch: [docs/readme-user-facing-trim](https://github.com/PhiloLabs/agentic-vbench/tree/docs/readme-user-facing-trim)
- Rendered README: [README.md on branch](https://github.com/PhiloLabs/agentic-vbench/blob/docs/readme-user-facing-trim/README.md)