### PR TITLE
README: use avb as the primary entry point in Quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,23 +32,24 @@ python3 -m venv .venv && .venv/bin/pip install --upgrade pip
 
 ### 2. Run one task with an agent
 
-Pick any agent supported by Harbor (`claude-code`, `codex`, `gemini-cli`, `opencode`, …) and pass its credentials with `--ae`:
+Pick any agent supported by Harbor (`claude-code`, `codex`, `gemini-cli`, `opencode`, …), export the matching API key, and run via the `./avb` CLI (a thin wrapper that auto-injects per-agent + per-family env vars into `harbor run`):
 
 ```bash
 # Claude Code (Anthropic):
-harbor run -p tasks/agentic_vbench_repair/exp-codec-restore-task01 \
-           -e modal -a claude-code -m anthropic/claude-sonnet-4-6 \
-           --ae ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
+export ANTHROPIC_API_KEY=...
+./avb run exp-codec-restore-task01 -a claude-code -m anthropic/claude-sonnet-4-6
 
 # Codex (OpenAI):
-harbor run -p tasks/agentic_vbench_repair/exp-codec-restore-task01 \
-           -e modal -a codex -m openai/gpt-5.5 \
-           --ae OPENAI_API_KEY=$OPENAI_API_KEY
+export OPENAI_API_KEY=...
+./avb run exp-codec-restore-task01 -a codex -m openai/gpt-5.5
 ```
+
+For `agentic_vbench_repurpose` tasks the **verifier** additionally needs `GEMINI_API_KEY` (the rubric LLM judge uses Gemini for audio/video grading) — export it and `avb` will forward it via Harbor's `--ve` flag.
 
 Inspect the result:
 
 ```bash
+./avb results show          # rewards from the latest job
 cat jobs/<job-name>/*/steps/solve/verifier/reward.json
 # {
 #   "reward": 0.55,
@@ -56,7 +57,7 @@ cat jobs/<job-name>/*/steps/solve/verifier/reward.json
 # }
 ```
 
-For `agentic_vbench_repurpose` tasks the **verifier** also needs `GEMINI_API_KEY` (the rubric LLM judge uses Gemini for audio/video grading) — pass it via Harbor's `--ve` flag.
+Run `./avb -h` to see every subcommand (`tasks list / check / env`, `run`, `rollout`, `results show`).
 
 ### 3. Run a full family in parallel
 
@@ -64,29 +65,10 @@ For `agentic_vbench_repurpose` tasks the **verifier** also needs `GEMINI_API_KEY
 export ANTHROPIC_API_KEY=...
 export MODAL_TOKEN_ID=... MODAL_TOKEN_SECRET=...
 
-.venv/bin/python scripts/parallel_rollout.py \
-    --mode claude --env modal --max-parallel 20 \
-    --tasks $(ls tasks/agentic_vbench_repair/ | tr '\n' ' ')
+./avb rollout --family repair --agent claude-code --env modal --max-parallel 20
 ```
 
 Same pattern for the other families. Per-task rewards land in `logs/rollout-results.tsv`; full per-trial artifacts (agent trajectory, verifier breakdown) under `jobs/<job-name>/`.
-
----
-
-## 🛠️ `avb` — convenience CLI
-
-A thin discoverability wrapper over Harbor lives at `./avb` in the repo root. It auto-injects per-agent and per-family env vars, lists tasks, and aggregates rewards.
-
-```bash
-./avb --help                                 # all subcommands
-./avb tasks list --family repair             # list tasks in a family
-./avb tasks env boxing                       # show env-var requirements
-./avb run exp-codec-restore-task01 -a codex -m openai/gpt-5.5
-./avb rollout --family repair --agent claude-code
-./avb results show                           # rewards from the latest job
-```
-
-`avb` calls `harbor run` / `harbor check` under the hood — the harness is unchanged. Anywhere `avb` works, the equivalent direct `harbor` invocation works too.
 
 ---
 


### PR DESCRIPTION
## Summary

Quick start now leads with \`./avb run\` instead of raw \`harbor run --ae ...\`:
- One env-var export + one \`avb run\` line per agent example.
- Drops the duplicated \"\`avb\` — convenience CLI\" section; folded into a single \`./avb -h\` pointer.
- Full-family example uses \`./avb rollout --family ...\` instead of the bare \`parallel_rollout.py\`.

Net: -19 lines, fewer copy-paste mistakes, agents have one entry point to learn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)