### PR TITLE
docs: add overall_fig hero image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # agentic-vbench
 
+<p align="center">
+  <img src="asset/overall_fig.png" alt="AgenticVBench: four task families — Assembly, Repair, Sequencing, Repurpose" width="100%">
+</p>
+
 A benchmark suite for evaluating AI coding agents on **video and audio editing tasks**. Built on top of [Harbor](https://www.harborframework.com/) — agent installation, sandboxed execution, concurrency, and trial scoring are handled for you.
 
 Four task families, **100 tasks total**, every task scored on a 0–1 scale.


### PR DESCRIPTION
## Summary

- Embed the four-task-family overview figure (`asset/overall_fig.png`) at the top of the README so first-time visitors see what AgenticVBench measures (Assembly / Repair / Sequencing / Repurpose) before the suite breakdown table.
- New `asset/` directory at the repo root for README-embedded figures.

This is the first in a series of small README-quality PRs (badge swarm, Updates section, Evaluation Results, BibTeX, etc. — each landing separately).

## Test plan

- [ ] GitHub renders `asset/overall_fig.png` inline at the top of README.md on the PR's Files-changed view.
- [ ] No other files modified (verify only `README.md` + `asset/overall_fig.png` in the diff).