### PR TITLE
docs: rewrite README tagline to lead with the benchmark claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # agentic-vbench
 
-A benchmark suite for evaluating AI coding agents on **video and audio editing tasks**. Built on top of [Harbor](https://www.harborframework.com/) — agent installation, sandboxed execution, concurrency, and trial scoring are handled for you.
+**AgenticVBench** is a 100-task benchmark for evaluating AI agents on real-world video post-production workflows — **Assembly**, **Repair**, **Sequencing**, and **Repurpose**. Tasks are authored by 20 industry experts (avg. 6 years of professional experience) and scored on a 0–1 scale, mixing programmatic verifiers with rubric-based LLM judges.
 
-Four task families, **100 tasks total**, every task scored on a 0–1 scale.
+Built on [Harbor](https://www.harborframework.com/) — agent installation, sandboxed execution, concurrency, and trial scoring are handled for you.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace the opening "AI coding agents on video and audio editing tasks" framing with a tighter opener that names the four families inline (Assembly, Repair, Sequencing, Repurpose), surfaces the 20-expert authorship, and notes the verifier + rubric scoring mix.
- Drop the now-redundant "Four task families, 100 tasks total" follow-up — the new opener already states both.
- Keep Harbor as a one-liner credit on its own line.

Independent of #21 (hero figure); both diffs target the same region but don't overlap, so they can land in any order.

## Test plan

- [ ] Diff is two lines changed in README.md, no other files touched.
- [ ] Render the PR's README preview on GitHub and confirm the new paragraph reads cleanly above the existing "What's in the suite" table.