### PR TITLE
fix: restore repair oracle by fetching golden at solve time

### DIFF
--- a/tasks/agentic_vbench_repair/exp-codec-restore-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-codec-restore-task01/steps/solve/solution/solve.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# Oracle: copy the pre-baked golden into the agent-output path.
-# Golden was baked into /baked/golden/ at `docker build` time.
+# Oracle: fetch the golden from HF at solve time, then copy to the
+# agent-output path. MATERIALS_URL is injected via [solution.env] in
+# task.toml — present only when Harbor runs the oracle agent.
 set -euo pipefail
+
+# Fetch the golden assets at solve time. MATERIALS_URL is injected via
+# [solution.env] in task.toml — present only when Harbor runs the
+# oracle agent. The agent step never sees this var.
+mkdir -p /workspace/output /tmp/g
+curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+     "$MATERIALS_URL" -o /tmp/g.zip
+unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
-cp /baked/golden/clean.wav /workspace/output/enhanced.wav
-echo "oracle: copied /baked/golden/clean.wav -> /workspace/output/enhanced.wav"
+cp /tmp/g/golden/clean.wav /workspace/output/enhanced.wav
+echo "oracle: copied /tmp/g/golden/clean.wav -> /workspace/output/enhanced.wav"

--- a/tasks/agentic_vbench_repair/exp-codec-restore-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-codec-restore-task01/task.toml
@@ -28,3 +28,6 @@ timeout_sec = 1800.0
 
 [steps.verifier.env]
 MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-codec-restore-task01.zip"
+
+[solution.env]
+MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-codec-restore-task01.zip"

--- a/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/steps/solve/solution/solve.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# Oracle: copy the pre-baked golden into the agent-output path.
-# Golden was baked into /baked/golden/ at `docker build` time.
+# Oracle: fetch the golden from HF at solve time, then copy to the
+# agent-output path. MATERIALS_URL is injected via [solution.env] in
+# task.toml — present only when Harbor runs the oracle agent.
 set -euo pipefail
+
+# Fetch the golden assets at solve time. MATERIALS_URL is injected via
+# [solution.env] in task.toml — present only when Harbor runs the
+# oracle agent. The agent step never sees this var.
+mkdir -p /workspace/output /tmp/g
+curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+     "$MATERIALS_URL" -o /tmp/g.zip
+unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
-cp /baked/golden/original.mp4 /workspace/output/output.mp4
-echo "oracle: copied /baked/golden/original.mp4 -> /workspace/output/output.mp4"
+cp /tmp/g/golden/original.mp4 /workspace/output/output.mp4
+echo "oracle: copied /tmp/g/golden/original.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/task.toml
@@ -30,3 +30,6 @@ timeout_sec = 1800.0
 
 [steps.verifier.env]
 MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-color-shot-gobelins-task01.zip"
+
+[solution.env]
+MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-color-shot-gobelins-task01.zip"

--- a/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/steps/solve/solution/solve.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# Oracle: copy the pre-baked golden into the agent-output path.
-# Golden was baked into /baked/golden/ at `docker build` time.
+# Oracle: fetch the golden from HF at solve time, then copy to the
+# agent-output path. MATERIALS_URL is injected via [solution.env] in
+# task.toml — present only when Harbor runs the oracle agent.
 set -euo pipefail
+
+# Fetch the golden assets at solve time. MATERIALS_URL is injected via
+# [solution.env] in task.toml — present only when Harbor runs the
+# oracle agent. The agent step never sees this var.
+mkdir -p /workspace/output /tmp/g
+curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+     "$MATERIALS_URL" -o /tmp/g.zip
+unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
-cp /baked/golden/original.mp4 /workspace/output/output.mp4
-echo "oracle: copied /baked/golden/original.mp4 -> /workspace/output/output.mp4"
+cp /tmp/g/golden/original.mp4 /workspace/output/output.mp4
+echo "oracle: copied /tmp/g/golden/original.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/task.toml
@@ -30,3 +30,6 @@ timeout_sec = 1800.0
 
 [steps.verifier.env]
 MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-color-shot-v3-s1-task01.zip"
+
+[solution.env]
+MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-color-shot-v3-s1-task01.zip"

--- a/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/steps/solve/solution/solve.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# Oracle: copy the pre-baked golden into the agent-output path.
-# Golden was baked into /baked/golden/ at `docker build` time.
+# Oracle: fetch the golden from HF at solve time, then copy to the
+# agent-output path. MATERIALS_URL is injected via [solution.env] in
+# task.toml — present only when Harbor runs the oracle agent.
 set -euo pipefail
+
+# Fetch the golden assets at solve time. MATERIALS_URL is injected via
+# [solution.env] in task.toml — present only when Harbor runs the
+# oracle agent. The agent step never sees this var.
+mkdir -p /workspace/output /tmp/g
+curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+     "$MATERIALS_URL" -o /tmp/g.zip
+unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
-cp /baked/golden/original.mp4 /workspace/output/output.mp4
-echo "oracle: copied /baked/golden/original.mp4 -> /workspace/output/output.mp4"
+cp /tmp/g/golden/original.mp4 /workspace/output/output.mp4
+echo "oracle: copied /tmp/g/golden/original.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/task.toml
@@ -30,3 +30,6 @@ timeout_sec = 1800.0
 
 [steps.verifier.env]
 MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-color-shot-visit-korea-task01.zip"
+
+[solution.env]
+MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-color-shot-visit-korea-task01.zip"

--- a/tasks/agentic_vbench_repair/exp-deblur-gaussian-mkbhd-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-deblur-gaussian-mkbhd-task01/steps/solve/solution/solve.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# Oracle: copy the pre-baked golden into the agent-output path.
-# Golden was baked into /baked/golden/ at `docker build` time.
+# Oracle: fetch the golden from HF at solve time, then copy to the
+# agent-output path. MATERIALS_URL is injected via [solution.env] in
+# task.toml — present only when Harbor runs the oracle agent.
 set -euo pipefail
+
+# Fetch the golden assets at solve time. MATERIALS_URL is injected via
+# [solution.env] in task.toml — present only when Harbor runs the
+# oracle agent. The agent step never sees this var.
+mkdir -p /workspace/output /tmp/g
+curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+     "$MATERIALS_URL" -o /tmp/g.zip
+unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
-cp /baked/golden/clean.mp4 /workspace/output/output.mp4
-echo "oracle: copied /baked/golden/clean.mp4 -> /workspace/output/output.mp4"
+cp /tmp/g/golden/clean.mp4 /workspace/output/output.mp4
+echo "oracle: copied /tmp/g/golden/clean.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-deblur-gaussian-mkbhd-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-deblur-gaussian-mkbhd-task01/task.toml
@@ -30,3 +30,6 @@ timeout_sec = 1800.0
 
 [steps.verifier.env]
 MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-deblur-gaussian-mkbhd-task01.zip"
+
+[solution.env]
+MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-deblur-gaussian-mkbhd-task01.zip"

--- a/tasks/agentic_vbench_repair/exp-deblur-motion-f1-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-deblur-motion-f1-task01/steps/solve/solution/solve.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# Oracle: copy the pre-baked golden into the agent-output path.
-# Golden was baked into /baked/golden/ at `docker build` time.
+# Oracle: fetch the golden from HF at solve time, then copy to the
+# agent-output path. MATERIALS_URL is injected via [solution.env] in
+# task.toml — present only when Harbor runs the oracle agent.
 set -euo pipefail
+
+# Fetch the golden assets at solve time. MATERIALS_URL is injected via
+# [solution.env] in task.toml — present only when Harbor runs the
+# oracle agent. The agent step never sees this var.
+mkdir -p /workspace/output /tmp/g
+curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+     "$MATERIALS_URL" -o /tmp/g.zip
+unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
-cp /baked/golden/clean.mp4 /workspace/output/output.mp4
-echo "oracle: copied /baked/golden/clean.mp4 -> /workspace/output/output.mp4"
+cp /tmp/g/golden/clean.mp4 /workspace/output/output.mp4
+echo "oracle: copied /tmp/g/golden/clean.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-deblur-motion-f1-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-deblur-motion-f1-task01/task.toml
@@ -30,3 +30,6 @@ timeout_sec = 1800.0
 
 [steps.verifier.env]
 MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-deblur-motion-f1-task01.zip"
+
+[solution.env]
+MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-deblur-motion-f1-task01.zip"

--- a/tasks/agentic_vbench_repair/exp-declip-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-declip-task01/steps/solve/solution/solve.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# Oracle: copy the pre-baked golden into the agent-output path.
-# Golden was baked into /baked/golden/ at `docker build` time.
+# Oracle: fetch the golden from HF at solve time, then copy to the
+# agent-output path. MATERIALS_URL is injected via [solution.env] in
+# task.toml — present only when Harbor runs the oracle agent.
 set -euo pipefail
+
+# Fetch the golden assets at solve time. MATERIALS_URL is injected via
+# [solution.env] in task.toml — present only when Harbor runs the
+# oracle agent. The agent step never sees this var.
+mkdir -p /workspace/output /tmp/g
+curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+     "$MATERIALS_URL" -o /tmp/g.zip
+unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
-cp /baked/golden/clean.wav /workspace/output/enhanced.wav
-echo "oracle: copied /baked/golden/clean.wav -> /workspace/output/enhanced.wav"
+cp /tmp/g/golden/clean.wav /workspace/output/enhanced.wav
+echo "oracle: copied /tmp/g/golden/clean.wav -> /workspace/output/enhanced.wav"

--- a/tasks/agentic_vbench_repair/exp-declip-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-declip-task01/task.toml
@@ -28,3 +28,6 @@ timeout_sec = 1800.0
 
 [steps.verifier.env]
 MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-declip-task01.zip"
+
+[solution.env]
+MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-declip-task01.zip"

--- a/tasks/agentic_vbench_repair/exp-dereverb-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-dereverb-task01/steps/solve/solution/solve.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# Oracle: copy the pre-baked golden into the agent-output path.
-# Golden was baked into /baked/golden/ at `docker build` time.
+# Oracle: fetch the golden from HF at solve time, then copy to the
+# agent-output path. MATERIALS_URL is injected via [solution.env] in
+# task.toml — present only when Harbor runs the oracle agent.
 set -euo pipefail
+
+# Fetch the golden assets at solve time. MATERIALS_URL is injected via
+# [solution.env] in task.toml — present only when Harbor runs the
+# oracle agent. The agent step never sees this var.
+mkdir -p /workspace/output /tmp/g
+curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+     "$MATERIALS_URL" -o /tmp/g.zip
+unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
-cp /baked/golden/clean.wav /workspace/output/enhanced.wav
-echo "oracle: copied /baked/golden/clean.wav -> /workspace/output/enhanced.wav"
+cp /tmp/g/golden/clean.wav /workspace/output/enhanced.wav
+echo "oracle: copied /tmp/g/golden/clean.wav -> /workspace/output/enhanced.wav"

--- a/tasks/agentic_vbench_repair/exp-dereverb-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-dereverb-task01/task.toml
@@ -28,3 +28,6 @@ timeout_sec = 1800.0
 
 [steps.verifier.env]
 MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-dereverb-task01.zip"
+
+[solution.env]
+MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-dereverb-task01.zip"

--- a/tasks/agentic_vbench_repair/exp-dns-denoise-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-dns-denoise-task01/steps/solve/solution/solve.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# Oracle: copy the pre-baked golden into the agent-output path.
-# Golden was baked into /baked/golden/ at `docker build` time.
+# Oracle: fetch the golden from HF at solve time, then copy to the
+# agent-output path. MATERIALS_URL is injected via [solution.env] in
+# task.toml — present only when Harbor runs the oracle agent.
 set -euo pipefail
+
+# Fetch the golden assets at solve time. MATERIALS_URL is injected via
+# [solution.env] in task.toml — present only when Harbor runs the
+# oracle agent. The agent step never sees this var.
+mkdir -p /workspace/output /tmp/g
+curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+     "$MATERIALS_URL" -o /tmp/g.zip
+unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
-cp /baked/golden/clean.wav /workspace/output/enhanced.wav
-echo "oracle: copied /baked/golden/clean.wav -> /workspace/output/enhanced.wav"
+cp /tmp/g/golden/clean.wav /workspace/output/enhanced.wav
+echo "oracle: copied /tmp/g/golden/clean.wav -> /workspace/output/enhanced.wav"

--- a/tasks/agentic_vbench_repair/exp-dns-denoise-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-dns-denoise-task01/task.toml
@@ -28,3 +28,6 @@ timeout_sec = 1800.0
 
 [steps.verifier.env]
 MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-dns-denoise-task01.zip"
+
+[solution.env]
+MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-dns-denoise-task01.zip"

--- a/tasks/agentic_vbench_repair/exp-sr-4x-shot-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-sr-4x-shot-task01/steps/solve/solution/solve.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
-# Oracle: copy the pre-baked golden into the agent-output path.
-# Golden was baked into /baked/golden/ at `docker build` time.
+# Oracle: fetch the golden from HF at solve time, then copy to the
+# agent-output path. MATERIALS_URL is injected via [solution.env] in
+# task.toml — present only when Harbor runs the oracle agent.
 set -euo pipefail
+
+# Fetch the golden assets at solve time. MATERIALS_URL is injected via
+# [solution.env] in task.toml — present only when Harbor runs the
+# oracle agent. The agent step never sees this var.
+mkdir -p /workspace/output /tmp/g
+curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+     "$MATERIALS_URL" -o /tmp/g.zip
+unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
-cp /baked/golden/original.mp4 /workspace/output/output.mp4
-cp /baked/golden/gt_shot.json /workspace/output/output.json
-echo "oracle: copied /baked/golden/original.mp4 -> /workspace/output/output.mp4"
+cp /tmp/g/golden/original.mp4 /workspace/output/output.mp4
+cp /tmp/g/golden/gt_shot.json /workspace/output/output.json
+echo "oracle: copied /tmp/g/golden/original.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-sr-4x-shot-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-sr-4x-shot-task01/task.toml
@@ -30,3 +30,6 @@ timeout_sec = 1800.0
 
 [steps.verifier.env]
 MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-sr-4x-shot-task01.zip"
+
+[solution.env]
+MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-sr-4x-shot-task01.zip"

--- a/tasks/agentic_vbench_repair/exp-swap-car-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-swap-car-task01/steps/solve/solution/solve.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# Oracle: copy the pre-baked golden into the agent-output path.
-# Golden was baked into /baked/golden/ at `docker build` time.
+# Oracle: fetch the golden from HF at solve time, then copy to the
+# agent-output path. MATERIALS_URL is injected via [solution.env] in
+# task.toml — present only when Harbor runs the oracle agent.
 set -euo pipefail
+
+# Fetch the golden assets at solve time. MATERIALS_URL is injected via
+# [solution.env] in task.toml — present only when Harbor runs the
+# oracle agent. The agent step never sees this var.
+mkdir -p /workspace/output /tmp/g
+curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+     "$MATERIALS_URL" -o /tmp/g.zip
+unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
-cp /baked/golden/original.mp4 /workspace/output/output.mp4
-echo "oracle: copied /baked/golden/original.mp4 -> /workspace/output/output.mp4"
+cp /tmp/g/golden/original.mp4 /workspace/output/output.mp4
+echo "oracle: copied /tmp/g/golden/original.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-swap-car-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-swap-car-task01/task.toml
@@ -29,3 +29,6 @@ timeout_sec = 1800.0
 
 [steps.verifier.env]
 MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-swap-car-task01.zip"
+
+[solution.env]
+MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-swap-car-task01.zip"

--- a/tasks/agentic_vbench_repair/exp-swap-product-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-swap-product-task01/steps/solve/solution/solve.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# Oracle: copy the pre-baked golden into the agent-output path.
-# Golden was baked into /baked/golden/ at `docker build` time.
+# Oracle: fetch the golden from HF at solve time, then copy to the
+# agent-output path. MATERIALS_URL is injected via [solution.env] in
+# task.toml — present only when Harbor runs the oracle agent.
 set -euo pipefail
+
+# Fetch the golden assets at solve time. MATERIALS_URL is injected via
+# [solution.env] in task.toml — present only when Harbor runs the
+# oracle agent. The agent step never sees this var.
+mkdir -p /workspace/output /tmp/g
+curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+     "$MATERIALS_URL" -o /tmp/g.zip
+unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
-cp /baked/golden/original.mp4 /workspace/output/output.mp4
-echo "oracle: copied /baked/golden/original.mp4 -> /workspace/output/output.mp4"
+cp /tmp/g/golden/original.mp4 /workspace/output/output.mp4
+echo "oracle: copied /tmp/g/golden/original.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-swap-product-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-swap-product-task01/task.toml
@@ -29,3 +29,6 @@ timeout_sec = 1800.0
 
 [steps.verifier.env]
 MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-swap-product-task01.zip"
+
+[solution.env]
+MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-swap-product-task01.zip"

--- a/tasks/agentic_vbench_repair/exp-voicebank-denoise-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-voicebank-denoise-task01/steps/solve/solution/solve.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# Oracle: copy the pre-baked golden into the agent-output path.
-# Golden was baked into /baked/golden/ at `docker build` time.
+# Oracle: fetch the golden from HF at solve time, then copy to the
+# agent-output path. MATERIALS_URL is injected via [solution.env] in
+# task.toml — present only when Harbor runs the oracle agent.
 set -euo pipefail
+
+# Fetch the golden assets at solve time. MATERIALS_URL is injected via
+# [solution.env] in task.toml — present only when Harbor runs the
+# oracle agent. The agent step never sees this var.
+mkdir -p /workspace/output /tmp/g
+curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+     "$MATERIALS_URL" -o /tmp/g.zip
+unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
-cp /baked/golden/clean.wav /workspace/output/enhanced.wav
-echo "oracle: copied /baked/golden/clean.wav -> /workspace/output/enhanced.wav"
+cp /tmp/g/golden/clean.wav /workspace/output/enhanced.wav
+echo "oracle: copied /tmp/g/golden/clean.wav -> /workspace/output/enhanced.wav"

--- a/tasks/agentic_vbench_repair/exp-voicebank-denoise-task01/task.toml
+++ b/tasks/agentic_vbench_repair/exp-voicebank-denoise-task01/task.toml
@@ -28,3 +28,6 @@ timeout_sec = 1800.0
 
 [steps.verifier.env]
 MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-voicebank-denoise-task01.zip"
+
+[solution.env]
+MATERIALS_URL = "https://huggingface.co/datasets/ameddserM/agentic_vbench_video_repair/resolve/main/materials/exp-voicebank-denoise-task01.zip"


### PR DESCRIPTION
## Summary

PR #18 isolated the golden assets out of \`/baked/\` and into a verifier-time fetch (\`[steps.verifier.env].MATERIALS_URL\` + \`test.sh\` curl). The matching change for the oracle was missed — each repair task's \`solve.sh\` still referenced \`/baked/golden/<file>\`, so \`harbor run -a oracle\` errored on every affected repair task.

This patch mirrors the verifier-side fix on the oracle side:

- **\`task.toml\`**: add a top-level \`[solution.env]\` block with \`MATERIALS_URL\`. Harbor injects this only during the oracle solve step, never during the agent step — so the isolation invariant is preserved.
- **\`solve.sh\`**: \`curl\` + \`unzip\` the golden at solve time into \`/tmp/g/golden/\`, then copy from there into \`/workspace/output/\`.

13 affected tasks (the ones whose oracle directly uses the golden as the output): codec-restore, color-shot × 3, deblur × 2, declip, dereverb, dns-denoise, sr-4x-shot, swap × 2, voicebank-denoise. The 5 cuts/disfluency/glitch oracles already compute their own answer inline and were unaffected.

## Verification

Smoke-tested on \`exp-codec-restore-task01\` against Modal:

\`\`\`
$ cat oracle.txt
oracle: copied /tmp/g/golden/clean.wav -> /workspace/output/enhanced.wav
\`\`\`

The solve step executed end-to-end: MATERIALS_URL was injected, \`curl\` + \`unzip\` + \`cp\` all succeeded, and \`enhanced.wav\` was produced from \`/tmp/g/golden/clean.wav\`. The verifier didn't complete in this particular run due to an intermittent harbor↔modal handoff hang (same issue we've seen before on long-running trials), but the solve-side proof is the binding test for this PR.

## Test plan

- [x] \`harbor check\` parses all 13 patched task.toml files cleanly
- [x] Local diff confirms each \`solve.sh\` swaps \`/baked/golden\` → \`/tmp/g/golden\` and prepends the fetch block after \`set -euo pipefail\`
- [x] Modal solve run on codec-restore produced \`enhanced.wav\` from the freshly-fetched golden

🤖 Generated with [Claude Code](https://claude.com/claude-code)