### PR TITLE
docs: add paper/leaderboard badges, broaden executor coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # agentic-vbench
 
 <p align="center">
+  <a href="paper/paper.pdf"><img src="https://img.shields.io/badge/📖_Paper-PDF-blue" alt="Paper"></a>
+  <a href="https://agenticvbench.com/leaderboard"><img src="https://img.shields.io/badge/🏆_Leaderboard-Live-yellow" alt="Leaderboard"></a>
+  <a href="https://huggingface.co/ameddserM"><img src="https://img.shields.io/badge/🤗_Datasets-HuggingFace-orange" alt="HF Datasets"></a>
+</p>
+
+<p align="center">
   <img src="asset/overall_fig.png" alt="AgenticVBench: four task families — Assembly, Repair, Sequencing, Repurpose" width="100%">
 </p>
 
@@ -78,11 +84,17 @@ Same pattern for the other families. Per-task rewards land in `logs/rollout-resu
 
 ## ⚙️ Supported executors
 
+Any executor that [Harbor](https://www.harborframework.com/) supports works — pass `-e <executor>` to `harbor run` (or `./avb run`). Common picks:
+
 | Executor | Use when | Required env |
 |---|---|---|
 | `docker` | Local sanity checks, single-task debugging | none |
 | `modal` | Large parallel runs across the suite | `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET` |
 | `daytona` | Cloud sandboxes (alternative to Modal) | `DAYTONA_API_KEY` |
+| `e2b` | Sandbox-as-a-service for code execution | `E2B_API_KEY` |
+| `runloop` | Long-running cloud workspaces | `RUNLOOP_API_KEY` |
+
+Plus `apple_container`, `gke`, `singularity`, `tensorlake`, and anything else Harbor adds — see Harbor's `--env` choices in `harbor run -h` for the live list.
 
 All task materials are hosted on Hugging Face under [`ameddserM/agentic_vbench_video_*`](https://huggingface.co/ameddserM) and baked into each task's Docker image at build time, so the same image runs on any executor without provider-specific configuration.
 


### PR DESCRIPTION
## Summary

Two README polish items:

1. **Badge row under the title** (Video-MME-v2 style) linking to the paper PDF, the live leaderboard at agenticvbench.com, and the HF datasets index.
2. **\"Supported executors\" section** now correctly says we support every executor Harbor does — listing the 5 most common in a table (docker / modal / daytona / e2b / runloop) plus a one-line mention of the rest (\`apple_container\`, \`gke\`, \`singularity\`, \`tensorlake\`) and a pointer at \`harbor run -h\` for the live list.

Net diff: README.md only, +12 −3 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)