### PR TITLE
docs: replace 🤗 Datasets badge with 🌐 Website badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # agentic-vbench
 
 <p align="center">
+  <a href="https://agenticvbench.com/"><img src="https://img.shields.io/badge/🌐_Website-agenticvbench.com-green" alt="Website"></a>
   <a href="paper/paper.pdf"><img src="https://img.shields.io/badge/📖_Paper-PDF-blue" alt="Paper"></a>
   <a href="https://agenticvbench.com/leaderboard"><img src="https://img.shields.io/badge/🏆_Leaderboard-Live-yellow" alt="Leaderboard"></a>
-  <a href="https://huggingface.co/ameddserM"><img src="https://img.shields.io/badge/🤗_Datasets-HuggingFace-orange" alt="HF Datasets"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Drops the badge pointing at the personal HF account page; adds a Website badge pointing at agenticvbench.com instead. Final badge order: Website → Paper → Leaderboard.

Also verified all 4 HF datasets (`ameddserM/agentic_vbench_video_{repair,assembly,sequencing,repurpose}`) are **publicly accessible** — anonymous `curl` returns 206 on a Range-header download for each, so no auth tokens needed for Docker image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)