### PR TITLE
docs+avb: surface oracle smoke, agent keys, tail hint, leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Built on [Harbor](https://www.harborframework.com/) — agent installation, sand
 | `agentic_vbench_sequencing` | 28 | Re-order a set of shuffled clips into the correct narrative sequence. |
 | `agentic_vbench_repurpose` | 36 | Re-cut a long-form source video into a short vertical clip that satisfies a per-task creative brief. |
 
-The `repair`, `assembly`, and `sequencing` families score with deterministic per-family judges and ship a bundled **golden solution** + **broken/random baseline** — by construction the golden scores 1.0 and the baseline scores 0.0. See [`docs/VERIFIER_DESIGN.md`](docs/VERIFIER_DESIGN.md) for the per-family scoring math. The `repurpose` family uses a rubric-based LLM-as-judge against a per-task creative brief (deterministic format checks + Gemini/Opus content judges; same 0–1 reward shape).
+The `repair`, `assembly`, and `sequencing` families score with deterministic per-family judges and ship a bundled **oracle solver** + **broken/random baseline** — by construction the oracle scores 1.0 and the baseline scores 0.0. See [`docs/VERIFIER_DESIGN.md`](docs/VERIFIER_DESIGN.md) for the per-family scoring math. The `repurpose` family uses a rubric-based LLM-as-judge against a per-task creative brief (deterministic format checks + Gemini/Opus content judges; same 0–1 reward shape) — running it requires both `GEMINI_API_KEY` and `ANTHROPIC_API_KEY` on the verifier side.
+
+Typical model scores live on the [leaderboard](https://agenticvbench.com/leaderboard) — use it to gauge whether your run is in the expected range.
 
 ---
 
@@ -54,9 +56,31 @@ export OPENAI_API_KEY=...
 ./avb run exp-codec-restore-task01 -a codex -m openai/gpt-5.5
 ```
 
-For `agentic_vbench_repurpose` tasks the **verifier** additionally needs `GEMINI_API_KEY` (the rubric LLM judge uses Gemini for audio/video grading) — export it and `avb` will forward it via Harbor's `--ve` flag.
+For `agentic_vbench_repurpose` tasks the **verifier** additionally needs `GEMINI_API_KEY` (the rubric LLM judge uses Gemini for audio/video grading) — export it and `avb` will forward it via Harbor's `--ve` flag. Run `./avb tasks env <task>` to see what credentials a given task and agent combo need.
 
-Inspect the result:
+**Free smoke test (no agent API spend).** Every repair/assembly/sequencing task ships a bundled oracle solver. Use it to confirm the harness is wired up end-to-end:
+
+```bash
+./avb run exp-codec-restore-task01 -a oracle -e docker
+# reward.json → ≈ 1.0, ~30 s on a cached image, zero agent cost
+```
+
+**Time + cost budget.** A real-agent rollout on Modal typically takes ~10 min per task wall clock. Cost depends entirely on agent + model — order-of-magnitude $0.10–$2 per task with mid-tier models, scaling linearly with the agent's token use. Plan accordingly for a 100-task sweep.
+
+**Here's what a task prompt actually looks like** (`exp-codec-restore-task01`):
+
+> # Restore A Muffled Stretch Of Audio
+>
+> I have a short mono speech recording at `/workspace/materials/noisy.wav`. For a stretch in it, the audio sounds muffled — like the high end has been chopped off and the voice lost its sparkle. The rest of the recording sounds clean and full.
+>
+> Please restore the muffled stretch so it sounds as clear and full as the rest of the recording. Leave the already-clean parts unchanged.
+>
+> ## What to deliver
+> - `/workspace/output/enhanced.wav` — 16-bit PCM mono at 16 kHz, same total length (sample count) as the input.
+
+Each task ships its own such brief at `tasks/<family>/<task>/steps/solve/instruction.md`.
+
+**Inspect the result:**
 
 ```bash
 ./avb results show          # rewards from the latest job
@@ -66,6 +90,8 @@ cat jobs/<job-name>/*/steps/solve/verifier/reward.json
 #   "details": { "reason": "ok", ... }
 # }
 ```
+
+While a trial is running, `./avb run` prints `tail -F jobs/<job>/*/trial.log` — copy that to watch progress in another shell.
 
 Run `./avb -h` to see every subcommand (`tasks list / check / env`, `run`, `rollout`, `results show`).
 

--- a/scripts/avb.py
+++ b/scripts/avb.py
@@ -84,18 +84,38 @@ def cmd_tasks_env(args: argparse.Namespace) -> int:
     cfg = tomllib.loads((p / "task.toml").read_text())
     agent_env = list(cfg.get("environment", {}).get("env", {}).keys())
     verifier_env = FAMILY_VERIFIER_ENV.get(fam, [])
-    print(f"task:      {args.task}")
-    print(f"family:    {fam}")
-    print(f"agent --ae:    {', '.join(agent_env) if agent_env else '(none)'}")
-    print(f"verifier --ve: {', '.join(verifier_env) if verifier_env else '(none)'}")
+    print(f"task:                 {args.task}")
+    print(f"family:                {fam}")
+    print(f"agent --ae (task-declared):   {', '.join(agent_env) if agent_env else '(none)'}")
+    print(f"verifier --ve (family-implied): {', '.join(verifier_env) if verifier_env else '(none)'}")
+    # Agent-side credential matrix — what `./avb run` injects automatically
+    # based on the -a flag. Even when the task itself declares no env, the
+    # agent runtime still needs its own API key.
+    print()
+    print("agent-side keys (auto-injected by `./avb run` based on -a):")
+    for ag, key in AGENT_ENV.items():
+        if key is None:
+            print(f"  -a {ag:<12s} (no key needed)")
+        else:
+            print(f"  -a {ag:<12s} {key}")
     return 0
 
 
 # ---- run -------------------------------------------------------------------
 def cmd_run(args: argparse.Namespace) -> int:
+    import time
     p = task_dir(args.task)
     fam = p.parent.name
-    cmd = ["harbor", "run", "-p", str(p), "-e", args.env, "-a", args.agent]
+    # Deterministic job name so the user can tail the trial log from a
+    # known path. Harbor still creates a child trial dir under this name.
+    job_name = f"avb-{args.task}-{int(time.time())}"
+    cmd = [
+        "harbor", "run",
+        "-p", str(p),
+        "-e", args.env,
+        "-a", args.agent,
+        "--job-name", job_name,
+    ]
     if args.model:
         cmd += ["-m", args.model]
     # Inject agent env if we know what the agent expects and the user has it.
@@ -115,6 +135,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     if args.yes:
         cmd += ["--yes"]
     print("+", " ".join(cmd), file=sys.stderr)
+    print(f"  tail this trial:  tail -F jobs/{job_name}/*/trial.log", file=sys.stderr)
     return subprocess.call(cmd)
 
 


### PR DESCRIPTION
## Summary

Six small polish items based on first-time-user feedback. Targeted: improve discoverability without bloating the README or adding new subcommands.

### avb changes (`scripts/avb.py`)

- **`avb tasks env`** now also prints the agent-side credential matrix (the AGENT_ENV map). Previously \`agent --ae: (none)\` was misleading — even when the task declares no env, the agent runtime still needs its own API key. Now we show both.
- **`avb run`** uses a deterministic \`--job-name\` and prints \`tail -F jobs/<job>/*/trial.log\` at start, so users can watch progress in another shell instead of staring at a quiet stdout for 10+ min.

### README changes

- **\"Golden solution\" → \"oracle solver\"** in the families paragraph (the bytes aren't bundled in the repo; the script that produces them is).
- **Leaderboard pointer** for typical-score reference (one line under the families paragraph — keeps numbers off the README, which would rot).
- **`GEMINI_API_KEY` / `ANTHROPIC_API_KEY` for repurpose verifier** moved next to the family description (was buried later).
- **Free oracle smoke recipe** in §2: \`./avb run <task> -a oracle -e docker\` → ≈1.0 reward, ~30s, no API cost. Lets users validate their install before spending budget.
- **Time + cost budget line** in §2 (~10 min/task wall clock, $0.10–$2/task order-of-magnitude with mid-tier models).
- **Real instruction.md excerpt** pasted in §2 — concrete sense of what a task brief looks like.

Net diff: README +30/-3, avb.py +26/-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)