### PR TITLE
fix: unzip -qo on /tmp/g.zip so oracle + verifier don't deadlock

### DIFF
--- a/tasks/agentic_vbench_repair/exp-codec-restore-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-codec-restore-task01/steps/solve/solution/solve.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 mkdir -p /workspace/output /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
 cp /tmp/g/golden/clean.wav /workspace/output/enhanced.wav
 echo "oracle: copied /tmp/g/golden/clean.wav -> /workspace/output/enhanced.wav"

--- a/tasks/agentic_vbench_repair/exp-codec-restore-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-codec-restore-task01/steps/solve/tests/test.sh
@@ -16,7 +16,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/steps/solve/solution/solve.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 mkdir -p /workspace/output /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
 cp /tmp/g/golden/original.mp4 /workspace/output/output.mp4
 echo "oracle: copied /tmp/g/golden/original.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-color-shot-gobelins-task01/steps/solve/tests/test.sh
@@ -13,7 +13,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/steps/solve/solution/solve.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 mkdir -p /workspace/output /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
 cp /tmp/g/golden/original.mp4 /workspace/output/output.mp4
 echo "oracle: copied /tmp/g/golden/original.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-color-shot-v3-s1-task01/steps/solve/tests/test.sh
@@ -13,7 +13,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/steps/solve/solution/solve.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 mkdir -p /workspace/output /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
 cp /tmp/g/golden/original.mp4 /workspace/output/output.mp4
 echo "oracle: copied /tmp/g/golden/original.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-color-shot-visit-korea-task01/steps/solve/tests/test.sh
@@ -13,7 +13,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-content-cut-mkbhd-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-content-cut-mkbhd-task01/steps/solve/tests/test.sh
@@ -14,7 +14,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-content-cut-wsj-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-content-cut-wsj-task01/steps/solve/tests/test.sh
@@ -14,7 +14,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-deblur-gaussian-mkbhd-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-deblur-gaussian-mkbhd-task01/steps/solve/solution/solve.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 mkdir -p /workspace/output /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
 cp /tmp/g/golden/clean.mp4 /workspace/output/output.mp4
 echo "oracle: copied /tmp/g/golden/clean.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-deblur-gaussian-mkbhd-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-deblur-gaussian-mkbhd-task01/steps/solve/tests/test.sh
@@ -13,7 +13,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-deblur-motion-f1-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-deblur-motion-f1-task01/steps/solve/solution/solve.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 mkdir -p /workspace/output /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
 cp /tmp/g/golden/clean.mp4 /workspace/output/output.mp4
 echo "oracle: copied /tmp/g/golden/clean.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-deblur-motion-f1-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-deblur-motion-f1-task01/steps/solve/tests/test.sh
@@ -24,7 +24,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-declip-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-declip-task01/steps/solve/solution/solve.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 mkdir -p /workspace/output /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
 cp /tmp/g/golden/clean.wav /workspace/output/enhanced.wav
 echo "oracle: copied /tmp/g/golden/clean.wav -> /workspace/output/enhanced.wav"

--- a/tasks/agentic_vbench_repair/exp-declip-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-declip-task01/steps/solve/tests/test.sh
@@ -9,7 +9,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-dereverb-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-dereverb-task01/steps/solve/solution/solve.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 mkdir -p /workspace/output /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
 cp /tmp/g/golden/clean.wav /workspace/output/enhanced.wav
 echo "oracle: copied /tmp/g/golden/clean.wav -> /workspace/output/enhanced.wav"

--- a/tasks/agentic_vbench_repair/exp-dereverb-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-dereverb-task01/steps/solve/tests/test.sh
@@ -9,7 +9,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-disfluency-interview-3-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-disfluency-interview-3-task01/steps/solve/tests/test.sh
@@ -14,7 +14,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-disfluency-interview-4-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-disfluency-interview-4-task01/steps/solve/tests/test.sh
@@ -14,7 +14,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-dns-denoise-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-dns-denoise-task01/steps/solve/solution/solve.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 mkdir -p /workspace/output /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
 cp /tmp/g/golden/clean.wav /workspace/output/enhanced.wav
 echo "oracle: copied /tmp/g/golden/clean.wav -> /workspace/output/enhanced.wav"

--- a/tasks/agentic_vbench_repair/exp-dns-denoise-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-dns-denoise-task01/steps/solve/tests/test.sh
@@ -9,7 +9,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-glitch-dup-long-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-glitch-dup-long-task01/steps/solve/tests/test.sh
@@ -14,7 +14,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-sr-4x-shot-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-sr-4x-shot-task01/steps/solve/solution/solve.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 mkdir -p /workspace/output /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
 cp /tmp/g/golden/original.mp4 /workspace/output/output.mp4
 cp /tmp/g/golden/gt_shot.json /workspace/output/output.json

--- a/tasks/agentic_vbench_repair/exp-sr-4x-shot-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-sr-4x-shot-task01/steps/solve/tests/test.sh
@@ -16,7 +16,7 @@ python3 -c "import cv2, numpy, skimage" 2>/dev/null || \
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-swap-car-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-swap-car-task01/steps/solve/solution/solve.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 mkdir -p /workspace/output /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
 cp /tmp/g/golden/original.mp4 /workspace/output/output.mp4
 echo "oracle: copied /tmp/g/golden/original.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-swap-car-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-swap-car-task01/steps/solve/tests/test.sh
@@ -17,7 +17,7 @@ python3 -c "import cv2, numpy" 2>/dev/null || \
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-swap-product-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-swap-product-task01/steps/solve/solution/solve.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 mkdir -p /workspace/output /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
 cp /tmp/g/golden/original.mp4 /workspace/output/output.mp4
 echo "oracle: copied /tmp/g/golden/original.mp4 -> /workspace/output/output.mp4"

--- a/tasks/agentic_vbench_repair/exp-swap-product-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-swap-product-task01/steps/solve/tests/test.sh
@@ -17,7 +17,7 @@ python3 -c "import cv2, numpy" 2>/dev/null || \
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 

--- a/tasks/agentic_vbench_repair/exp-voicebank-denoise-task01/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_repair/exp-voicebank-denoise-task01/steps/solve/solution/solve.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 mkdir -p /workspace/output /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 mkdir -p /workspace/output
 cp /tmp/g/golden/clean.wav /workspace/output/enhanced.wav
 echo "oracle: copied /tmp/g/golden/clean.wav -> /workspace/output/enhanced.wav"

--- a/tasks/agentic_vbench_repair/exp-voicebank-denoise-task01/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_repair/exp-voicebank-denoise-task01/steps/solve/tests/test.sh
@@ -9,7 +9,7 @@ fi
 mkdir -p /tests /tmp/g
 curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
      "$MATERIALS_URL" -o /tmp/g.zip
-unzip -q /tmp/g.zip 'golden/*' -d /tmp/g
+unzip -qo /tmp/g.zip 'golden/*' -d /tmp/g
 cp -r /tmp/g/golden/. /tests/
 rm -rf /tmp/g.zip /tmp/g
 


### PR DESCRIPTION
## Summary

After PR #25, both the oracle (\`solve.sh\`) and the verifier (\`test.sh\`) independently unzip the same materials zip into \`/tmp/g/\` inside a single container. Neither call passed \`-o\` (overwrite), so the second unzip hit the first's files, prompted interactively, got EOF from the non-TTY container stdin, and aborted under \`set -euo pipefail\` — silently producing 0 trials instead of \`reward.json\`.

The README's free oracle smoke (\`./avb run <task> -a oracle -e docker\` → "reward ≈ 1.0, ~30 s on a cached image") therefore did **not** work post-#25. This PR makes it work.

## Fix

One-flag patch — \`unzip -q\` → \`unzip -qo\` in every repair script that unzips into \`/tmp/g/\`:

- **18 verifier \`test.sh\`** (introduced in PR #18)
- **13 oracle \`solve.sh\`** (introduced in PR #25)

\`-o\` makes the unzip idempotent regardless of which side ran first.

## Test plan

10 oracle trials across every repair subgroup, all on Modal with \`-a oracle\`:

| subgroup | task | reward |
|---|---|---|
| audio | dns-denoise | 1.0 |
| audio | dereverb | 1.0 |
| audio | declip (npy mask) | 1.0 |
| color | color-shot-visit-korea | 1.0 |
| deblur | deblur-motion-f1 (mask) | 1.0 |
| sr | sr-4x-shot | 1.0 |
| swap | swap-car | 1.0 |
| cut (verifier-only) | content-cut-mkbhd | 1.0 |
| disfluency (verifier-only) | disfluency-interview-3 | 1.0 |
| glitch (verifier-only) | glitch-dup-long | 1.0 |

10 / 10 = 1.0. Includes both the dual-unzip path (where the original deadlock lived) and the verifier-only-unzip path (where the same flag still defends against double-run scenarios).

🤖 Generated with [Claude Code](https://claude.com/claude-code)