### PR TITLE
docs: embed demo video in README, above Quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ Typical model scores live on the [leaderboard](https://agenticvbench.com/leaderb
 
 ---
 
+<p align="center">
+  <video
+    src="https://github.com/PhiloLabs/agentic-vbench/releases/download/media-v1/agenticvbench_final.mp4"
+    controls
+    width="100%"
+    muted>
+  </video>
+</p>
+
+---
+
 ## 🚀 Quick start
 
 ### 1. Install


### PR DESCRIPTION
Adds an inline `<video>` player above Quick start, pointing at `agenticvbench_final.mp4` on the `media-v1` release.

- Video hosted as a release asset (`https://github.com/PhiloLabs/agentic-vbench/releases/download/media-v1/agenticvbench_final.mp4`) — not committed to the repo, so the clone stays at ~9 MB.
- GitHub renders the HTML5 `<video>` tag inline in the README, so playback works directly on github.com without leaving the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)