### PR TITLE
docs: drop the inline <video> block from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,6 @@ Typical model scores live on the [leaderboard](https://agenticvbench.com/leaderb
 
 ---
 
-<p align="center">
-  <video
-    src="https://github.com/PhiloLabs/agentic-vbench/releases/download/media-v1/agenticvbench_final.mp4"
-    controls
-    width="100%"
-    muted>
-  </video>
-</p>
-
----
-
 ## 🚀 Quick start
 
 ### 1. Install


### PR DESCRIPTION
GitHub's README markdown sanitizer doesn't reliably render `<video>` tags pointing at release-asset URLs — the player just doesn't show up in the rendered page. Removes the block to clean up the gap between the families section and Quick start.

The `media-v1` release with `agenticvbench_final.mp4` (21.7 MB) stays — anyone can still download the demo from the [releases page](https://github.com/PhiloLabs/agentic-vbench/releases/tag/media-v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)