### PR TITLE
fix(verifier): paper-aligned scoring for assembly + sequencing

### DIFF
--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task1/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['10.mp4', '4.mp4', '6.mp4', '8.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task10/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['7.mp4', '5.mp4', '1.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task11/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['5.mp4', '4.mp4', '9.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task12/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['7.mp4', '6.mp4', '2.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task13/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['10.mp4', '12.mp4', '11.mp4', '5.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task14/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['8.mp4', '9.mp4', '2.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task15/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['4.mp4', '9.mp4', '2.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task16/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['5.mp4', '7.mp4', '6.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task17/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['6.mp4', '5.mp4', '1.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task18/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['6.mp4', '4.mp4', '2.mp4', '11.mp4', '14.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task2/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['2.mp4', '12.mp4', '9.mp4', '10.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task3/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['14.mp4', '6.mp4', '15.mp4', '10.mp4', '3.mp4', '1.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task4/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['8.mp4', '5.mp4', '9.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task5/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['1.mp4', '2.mp4', '8.mp4', '9.mp4', '12.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task6/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['5.mp4', '11.mp4', '2.mp4', '3.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task7/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['18.mp4', '13.mp4', '3.mp4', '2.mp4', '4.mp4', '12.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task8/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['5.mp4', '13.mp4', '10.mp4', '11.mp4', '3.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_assembly/agentic-vbench-assembly-task9/steps/solve/tests/judge.py
@@ -11,7 +11,8 @@ claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
 (same threshold the repair-task preservation gates use — robust to
 re-encoding noise, fails on real mismatch).
 
-Reward = (# slots that pass both gates) / n_slots.
+pass_rate p = (# slots that pass both gates) / n_slots.
+Reward = max(0, (p − 1/3) / (1 − 1/3)) — chance-corrected per-slot accuracy.
 """
 from __future__ import annotations
 
@@ -33,6 +34,10 @@ CORRECT_PICKS = ['8.mp4', '10.mp4', '7.mp4', '6.mp4', '11.mp4']
 
 SSIM_THRESHOLD = 0.95
 N_SAMPLES = 3  # at 25%, 50%, 75% through each segment
+
+CHANCE_LEVEL = 1.0 / 3.0  # paper's per-slot random baseline; reward is the
+                          # chance-corrected accuracy (p − chance)/(1 − chance),
+                          # floored at 0 to keep reward in [0, 1].
 
 
 def _normalize(src) -> str:
@@ -222,13 +227,18 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                     n_honest_correct += 1
         per_slot.append(slot)
 
+    p = n_honest_correct / n
+    reward = max(0.0, (p - CHANCE_LEVEL) / (1.0 - CHANCE_LEVEL))
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
             "n_honest_correct": n_honest_correct,
+            "pass_rate": p,
+            "chance_level": CHANCE_LEVEL,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/steps/solve/tests/judge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Score one agentic_vbench_sequencing solution: per-slot pick + SSIM honesty.
+"""Score one agentic_vbench_sequencing solution: ordering quality + SSIM honesty.
 
-Per-slot score:
-  slot_score = 1 iff pred[i] == CORRECT_ORDER[i] AND SSIM-honesty passes
-             = 0 otherwise
+Ordering metrics (agent's claimed order vs the golden order; vendored from
+the primary runner's grade kit):
+  ND  — normalized footrule displacement, sum|pred_pos − correct_pos| / (n²//2)
+  ADJ — fraction of golden adjacent transitions preserved, / (n−1)
+  LIS — longest correctly-ordered subsequence ratio, len(LIS) / len(pred)
+  ordering = (1 − ND) · ADJ · LIS   (= 1 for a perfect order)
 
 SSIM-honesty: sample 3 frames at 25%/50%/75% through each segment's
 output range in solution.mp4, sample the matching offsets from the
 claimed source clip's source_range, and require every pair's SSIM ≥ 0.95
-(same threshold the repair-task preservation gates use — robust to
-re-encoding noise, fails on real mismatch).
+(robust to re-encoding noise, fails on real mismatch). Run on every slot —
+under the partial-credit ordering metric a mis-placed clip still earns
+score, so its content must be verified too. honesty_factor is the fraction
+of slots that pass.
 
-Reward = (# slots that pass both gates) / n_slots.
+Reward = honesty_factor · ordering.
 """
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ import argparse
 import json
 import os
 import sys
+from bisect import bisect_left
 from pathlib import Path
 
 os.environ.setdefault("OPENCV_FFMPEG_THREADS", "1")
@@ -144,6 +150,45 @@ def _check_honesty(solution_mp4: Path, source_mp4: Path,
     return True, samples
 
 
+def _metric_nd(pred: list[str], correct: list[str]) -> float:
+    """Normalized footrule displacement, in [0, 1]; lower is better."""
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    correct_pos = {c: i for i, c in enumerate(correct)}
+    n = len(correct)
+    total = sum(abs(pred_pos[c] - correct_pos[c]) for c in correct_pos)
+    max_total = (n * n) // 2
+    return total / max_total if max_total else 0.0
+
+
+def _metric_lis(pred: list[str], correct: list[str]) -> float:
+    """Longest correctly-ordered subsequence ratio, in [0, 1]; higher better."""
+    rank = {c: i for i, c in enumerate(correct)}
+    seq = [rank[c] for c in pred if c in rank]
+    if not seq:
+        return 0.0
+    tails: list[int] = []
+    for x in seq:
+        i = bisect_left(tails, x)
+        if i == len(tails):
+            tails.append(x)
+        else:
+            tails[i] = x
+    return len(tails) / len(pred)
+
+
+def _metric_adj(pred: list[str], correct: list[str]) -> float:
+    """Fraction of true adjacent transitions caught, in [0, 1]; higher better."""
+    if len(correct) <= 1:
+        return 1.0
+    pred_pos = {c: i for i, c in enumerate(pred)}
+    caught = 0
+    for i in range(len(correct) - 1):
+        a, b = correct[i], correct[i + 1]
+        if pred_pos.get(b, -2) - pred_pos.get(a, -1) == 1:
+            caught += 1
+    return caught / (len(correct) - 1)
+
+
 def _zero(reason, pred=None):
     return {
         "reward": 0.0,
@@ -151,7 +196,7 @@ def _zero(reason, pred=None):
             "reason": reason,
             "n_slots": len(CORRECT_ORDER),
             "n_correct": 0,
-            "n_honest_correct": 0,
+            "n_honest": 0,
             "pred": pred or [],
             "correct": CORRECT_ORDER,
         },
@@ -181,6 +226,10 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
             pred=pred,
         )
 
+    nd = _metric_nd(pred, CORRECT_ORDER)
+    lis = _metric_lis(pred, CORRECT_ORDER)
+    adj = _metric_adj(pred, CORRECT_ORDER)
+    ordering = (1.0 - nd) * adj * lis
     n_correct = sum(1 for i in range(n) if pred[i] == CORRECT_ORDER[i])
 
     if not solution_mp4.exists():
@@ -190,43 +239,47 @@ def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
                 "reason": f"solution.mp4 not found at {solution_mp4}",
                 "n_slots": n,
                 "n_correct": n_correct,
-                "n_honest_correct": 0,
+                "nd": nd, "lis": lis, "adj": adj, "ordering": ordering,
+                "honesty_factor": 0.0,
                 "pred": pred,
                 "correct": CORRECT_ORDER,
             },
         }
 
+    # Honesty is verified on every slot: under the partial-credit ordering
+    # metric a mis-placed clip still earns score, so its content must be
+    # confirmed too (an exact-position-only check wouldn't catch a faked
+    # clip in a wrong slot). honesty_factor scales the ordering score.
     per_slot = []
-    n_honest_correct = 0
+    n_honest = 0
     for i in range(n):
-        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i]}
-        if pred[i] != CORRECT_ORDER[i]:
-            slot["match"] = False
-            slot["honest"] = None  # not checked
-            slot["score"] = 0
+        slot = {"slot": i, "pred": pred[i], "expected": CORRECT_ORDER[i],
+                "match": pred[i] == CORRECT_ORDER[i]}
+        source_path = materials_dir / f"{pred[i]}.mp4"
+        if not source_path.exists():
+            slot["honest"] = False
+            slot["honesty_reason"] = f"missing source clip {source_path}"
         else:
-            slot["match"] = True
-            source_path = materials_dir / f"{pred[i]}.mp4"
-            if not source_path.exists():
-                slot["honest"] = False
-                slot["honesty_reason"] = f"missing source clip {source_path}"
-                slot["score"] = 0
-            else:
-                honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
-                slot["honest"] = honest
-                slot["samples"] = samples
-                slot["score"] = 1 if honest else 0
-                if honest:
-                    n_honest_correct += 1
+            honest, samples = _check_honesty(solution_mp4, source_path, segments[i])
+            slot["honest"] = honest
+            slot["samples"] = samples
+            if honest:
+                n_honest += 1
         per_slot.append(slot)
 
+    honesty_factor = n_honest / n
+    reward = honesty_factor * ordering
+
     return {
-        "reward": n_honest_correct / n,
+        "reward": reward,
         "details": {
             "reason": "ok",
             "n_slots": n,
             "n_correct": n_correct,
-            "n_honest_correct": n_honest_correct,
+            "nd": nd, "lis": lis, "adj": adj,
+            "ordering": ordering,
+            "n_honest": n_honest,
+            "honesty_factor": honesty_factor,
             "ssim_threshold": SSIM_THRESHOLD,
             "n_samples_per_segment": N_SAMPLES,
             "pred": pred,


### PR DESCRIPTION
## What

Switches the **assembly** and **sequencing** verifiers from raw honesty-gated pass-rate (`n_correct/n`) to the paper-canonical scoring used by the primary `video-agent-runner` repo.

### Assembly (18 tasks)
Chance-corrected per-slot accuracy:
```
reward = max(0, (p - 1/3) / (1 - 1/3))     # p = honesty-gated pass-rate
```

### Sequencing (28 tasks)
Ordering-quality **product** (not the legacy `0.4(1-ND)+0.3·LIS+0.3·ADJ` weighted sum):
```
reward = honesty_factor * (1 - ND) * ADJ * LIS
```
`ND` / `LIS` / `ADJ` are vendored verbatim from `video_order/runner.py`:
- **ND** — normalized footrule displacement, `sum|pred_pos - correct_pos| / (n²//2)`
- **LIS** — longest correctly-ordered subsequence ratio, `len(LIS) / len(pred)`
- **ADJ** — directed adjacency hits `/ (n-1)`

## Honesty anti-cheat
The SSIM honesty check is **kept**. For sequencing it now runs on **every slot** (previously: exact-position matches only) — under a partial-credit ordering metric a mis-placed clip still earns score, so its content must be verified too. `honesty_factor = honest_slots / n`. Assembly's honesty is untouched (a wrong pick is 0 regardless).

## Scope
- 46 `judge.py` files only; no `task.toml` / `instruction.md` / `solve.sh` / `test.sh` / docs / scripts touched.
- Answer keys (`CORRECT_PICKS` / `CORRECT_ORDER`) unchanged.
- All files ruff-clean and compile; uniform across each family.

## Verification
- Oracle smokes (golden solution): **assembly-task1 = 1.0**, **sequencing-task1 = 1.0** (`nd=0, adj=1, lis=1, honesty_factor=1`).
- Math checks: perfect order → 1.0, reversed → 0.0, single swap → 0.75; assembly `p=1/3 → 0`, `p=1 → 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)