### PR TITLE
fix(sequencing): pin materials revision and verify checksum at build

### DIFF
--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/1.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/1.zip
+ARG MATERIALS_SHA256=657db511183757384636948a6fdb42b0eefe7143261aecdfa735bdc6a1acd0e4
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task1/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/10.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/10.zip
+ARG MATERIALS_SHA256=c66c999aafb1e9c83334ec200798b85f7250e60e7a271b4ea64f75d55abe9f37
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task10/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/11.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/11.zip
+ARG MATERIALS_SHA256=7615bc3791c028d293b9b8232b3bfd00f922be1745ebfe3bd43608838b8fb61b
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task11/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/12.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/12.zip
+ARG MATERIALS_SHA256=dc05887dbad1588ad55bacd39b129ab4d65f5f62af7fe9364511f7335e40a93d
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task12/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/13.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/13.zip
+ARG MATERIALS_SHA256=f6e40ae9b3c361a8e3f1f495fec9d8a58fbe0c3e323ede2360bb42538efab2e3
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task13/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/14.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/14.zip
+ARG MATERIALS_SHA256=a82d0bfb42a50188ad64ebd99d21f5661983a93894010d335df9da7126d2203f
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task14/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/15.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/15.zip
+ARG MATERIALS_SHA256=d9d1e0aa59c1c0292a79ed93545d4e3db69dad4877f351dfb2e819d1f6915ecb
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task15/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/16.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/16.zip
+ARG MATERIALS_SHA256=c6d535067edfb9b6f36f4ff02a91f68cae210f47a7889cd3dcf48984de980dbd
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task16/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/17.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/17.zip
+ARG MATERIALS_SHA256=e59a01c9e7f334efdedcea3660896dc99821800083e2ed546a3903904f16297a
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task17/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/18.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/18.zip
+ARG MATERIALS_SHA256=707ed323193af32b305159831ee85eddfd57f738c81052aabe8f501fcdf0e074
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task18/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/19.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/19.zip
+ARG MATERIALS_SHA256=ab7a47d97b507b7ff83a92ecfbe2e80208c8c55c87b27116aaf9f8afb67db3a1
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task19/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/2.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/2.zip
+ARG MATERIALS_SHA256=a03b2aaaf1f3212579aeed9cfeddd283abb2a1eb1d92a54b95ac86a08820251d
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task2/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/20.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/20.zip
+ARG MATERIALS_SHA256=502cd913a14234a15ad5ca397ad0c734ca7bb527bff03847d8d5f0172ba48261
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task20/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/21.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/21.zip
+ARG MATERIALS_SHA256=785180f86485aafd0befafbe2608db542db62aa4dcd41034c32820c3c4cc1e23
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task21/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/22.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/22.zip
+ARG MATERIALS_SHA256=0ee91d095768f542cc769a57b1e67513a755376aa0960f8fd7d41c50eaf960f5
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task22/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/23.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/23.zip
+ARG MATERIALS_SHA256=998660047f589d4506db65075775e7ae5198f249f4c0ba5afe248f3c64123b26
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task23/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/24.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/24.zip
+ARG MATERIALS_SHA256=4b668e7ff602859ce02c8ed6c1b172ec10cc5c8c914579912f39a70e407d5227
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task24/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/25.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/25.zip
+ARG MATERIALS_SHA256=6a1dd9ae324f808390a4f17df5141ddff82c9c85102abc99ec1e2a45debe7413
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task25/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/26.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/26.zip
+ARG MATERIALS_SHA256=cbcb2e845de35412e92a2167a04225bd121602c18608b69ac78ca6bfaaed8bcc
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task26/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/27.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/27.zip
+ARG MATERIALS_SHA256=6ef2e4514f8c482a86b9f70013622b6ad9b2d1fadf25c0ff9a444acb269e147b
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task27/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/28.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/28.zip
+ARG MATERIALS_SHA256=a4f775ef97d42157f7f559061a91632d0675ac73c8b34fb99ecc5f8e75c32719
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task28/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/3.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/3.zip
+ARG MATERIALS_SHA256=70466a33a8b7abaf917f883d97ff66ec16f4a1905923c6a826455ddcf24b1b77
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task3/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/4.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/4.zip
+ARG MATERIALS_SHA256=5eafa15a8d55be9607ed8c82945ccd0c6dd5470260445033470f915c250c0d35
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task4/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/5.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/5.zip
+ARG MATERIALS_SHA256=f4488af6dd3ee5f17a5d4ca3b15ca9c4c8bead8ff6f7dd1d59640638a128ba75
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task5/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/6.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/6.zip
+ARG MATERIALS_SHA256=f14394687f6a259223c24296e03efb446a99144877243f9c444fc5a988463a9b
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task6/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/7.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/7.zip
+ARG MATERIALS_SHA256=aeff61dbdf193e2b6985cabef6264e108144ee1e74614808474123b5517df06d
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task7/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/8.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/8.zip
+ARG MATERIALS_SHA256=aa3dabd9080e5c3167180d5bd84c3cbcad26e43bacb55648469daafea0ef75c8
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task8/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/environment/Dockerfile
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/environment/Dockerfile
@@ -10,10 +10,12 @@ RUN pip install --no-cache-dir \
 
 # Bake task materials at build time from the public video dataset.
 # Workers pull this prebuilt image — no trial-time HF fetch.
-ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/main/materials/9.zip
+ARG MATERIALS_URL=https://huggingface.co/datasets/ameddserM/agentic_vbench_video_sequencing/resolve/00e704c2053e2260a40ef8432fe34af8258888d3/materials/9.zip
+ARG MATERIALS_SHA256=fddd34f8ffd6263aa78143827971aea9ec5c342b3569c77b01df256ad5c3b912
 RUN mkdir -p /baked/materials \
  && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
       "$MATERIALS_URL" -o /tmp/m.zip \
+ && echo "${MATERIALS_SHA256}  /tmp/m.zip" | sha256sum -c - \
  && unzip -q /tmp/m.zip -d /baked/materials/ \
  && rm /tmp/m.zip
 

--- a/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_sequencing/agentic-vbench-sequencing-task9/steps/solve/tests/judge.py
@@ -203,7 +203,24 @@ def _zero(reason, pred=None):
     }
 
 
+class TaskMisconfiguredError(Exception):
+    """Provisioned materials do not match the answer key (CORRECT_ORDER);
+    the task is misconfigured. Fail loudly rather than producing a score."""
+
+
+def _assert_materials_match_key(materials_dir: Path) -> None:
+    provisioned = {p.stem for p in materials_dir.glob("*.mp4") if p.stem.isdigit()}
+    expected = set(CORRECT_ORDER)
+    if provisioned != expected:
+        order = lambda s: int(s) if s.isdigit() else 0
+        raise TaskMisconfiguredError(
+            f"materials clips {sorted(provisioned, key=order)} != answer-key clips "
+            f"{sorted(expected, key=order)} (have {len(provisioned)}, key wants {len(expected)})"
+        )
+
+
 def score(solution_json: Path, solution_mp4: Path, materials_dir: Path) -> dict:
+    _assert_materials_match_key(materials_dir)
     if not solution_json.exists():
         return _zero(f"solution.json not found at {solution_json}")
     try:
@@ -301,8 +318,17 @@ def main():
     parser.add_argument("--reward-txt", required=True, type=Path)
     args = parser.parse_args()
 
-    result = score(args.solution, args.solution_mp4, args.materials_dir)
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = score(args.solution, args.solution_mp4, args.materials_dir)
+    except TaskMisconfiguredError as e:
+        msg = f"TASK MISCONFIGURED (materials vs answer key out of sync): {e}"
+        print(msg, file=sys.stderr)
+        result = {"reward": None, "error": "task_misconfigured",
+                  "details": {"reason": msg, "correct": CORRECT_ORDER}}
+        args.reward_json.write_text(json.dumps(result, indent=2))
+        args.reward_txt.write_text("ERROR task_misconfigured\n")
+        return 2
     args.reward_json.write_text(json.dumps(result, indent=2))
     args.reward_txt.write_text(f"{result['reward']:.6f}\n")
     print(json.dumps(result, indent=2))


### PR DESCRIPTION
## Summary
Sequencing task materials were fetched from a mutable dataset ref with no integrity check, so a build could bake clips that don't match the verifier's answer key (e.g. when served from a stale build-layer cache), producing incorrect rewards.

## Changes
- **`environment/Dockerfile`** (all 28 tasks): pin the materials URL to an immutable dataset revision and verify the downloaded zip's `SHA256` with `sha256sum -c`. The build now fails loudly on any mismatch instead of baking unverified content (this also busts the layer cache).
- **`steps/solve/tests/judge.py`** (all 28 tasks): add a guard that the provisioned clips match the answer key and raise a clear error otherwise, rather than scoring against mismatched inputs.

## Verification
Oracle (golden-order) solve scores **reward 1.0** on all 28 tasks through the full build → run path, confirming materials and verifier are aligned and the checksum step passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)