### PR TITLE
Add agentic video-understanding area (agentic_vbench_understanding)

### DIFF
--- a/scripts/_task_paths.py
+++ b/scripts/_task_paths.py
@@ -1,9 +1,10 @@
 """Lookup helper for task dirs under `tasks/<family>/<task>`.
 
-Tasks live under one of four family subdirectories — `agentic_vbench_repair`,
-`agentic_vbench_assembly`, `agentic_vbench_sequencing`, `agentic_vbench_repurpose`
-— but downstream tooling generally only knows the task name, not the family.
-This module resolves names → paths and lists tasks by family.
+Tasks live under one of five family subdirectories — `agentic_vbench_repair`,
+`agentic_vbench_assembly`, `agentic_vbench_sequencing`, `agentic_vbench_repurpose`,
+`agentic_vbench_understanding` — but downstream tooling generally only knows the
+task name, not the family. This module resolves names → paths and lists tasks by
+family.
 """
 from __future__ import annotations
 
@@ -16,6 +17,7 @@ FAMILIES = (
     "agentic_vbench_assembly",
     "agentic_vbench_sequencing",
     "agentic_vbench_repurpose",
+    "agentic_vbench_understanding",
 )
 
 

--- a/scripts/understanding/check_task.py
+++ b/scripts/understanding/check_task.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Pre-submission checker for AgenticVBench video-understanding tasks.
+
+Validates the three things every task in this area must satisfy:
+
+  1. INPUT VIDEO   reachable + downloadable, length 10-300 min, height >= 720p.
+  2. ROLLOUT       a strong agent's run took > 50 tool-call turns (long-horizon).
+  3. CALIBRATION   oracle reward == 1.0, null/empty baseline <= 0.10, strong
+                   agent reward < 0.50.
+
+Each check runs only if you give it the inputs; skipped checks are reported. Exit
+status is non-zero if any provided check FAILS, so it drops into CI.
+
+Examples
+--------
+  # video only (needs ffprobe on PATH; yt-dlp for YouTube links)
+  python tools/check_task.py --video-url "https://archive.org/download/.../game.mp4"
+
+  # full check after a run
+  python tools/check_task.py \
+      --task-dir tasks/agentic_vbench_sports/gsw-cle-2018-finals-g4-boxscore \
+      --video-url "https://..." \
+      --oracle-reward jobs/<job>/reward.json \
+      --baseline-reward jobs/<empty>/reward.json \
+      --agent-reward jobs/<agent>/reward.json \
+      --agent-turns 73
+"""
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+MIN_MINUTES = 10
+MAX_MINUTES = 300
+MIN_HEIGHT = 720
+ORACLE_MIN = 0.999          # oracle must score 1.0
+BASELINE_MAX = 0.10         # null/empty baseline must be ~0
+AGENT_MAX = 0.10            # a strong agent must stay below this (hard task)
+MIN_TURNS = 50              # rollout must be long-horizon
+
+REQUIRED_FILES = [
+    "task.toml",
+    "environment/Dockerfile",
+    "steps/solve/instruction.md",
+    "steps/solve/solution/solve.sh",
+    "steps/solve/tests/judge.py",
+    "steps/solve/tests/test.sh",
+]
+
+results = []  # (name, status, message); status in {"PASS","FAIL","SKIP","WARN"}
+
+
+def record(name, status, message):
+    results.append((name, status, message))
+
+
+def read_reward(path):
+    return float(json.loads(Path(path).read_text())["reward"])
+
+
+def probe_archive_or_direct(url):
+    """Return (duration_s, height) via ffprobe, or raise."""
+    out = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0",
+         "-show_entries", "format=duration:stream=height",
+         "-of", "json", url],
+        capture_output=True, text=True, timeout=120,
+    )
+    if out.returncode != 0:
+        raise RuntimeError(out.stderr.strip() or "ffprobe failed")
+    data = json.loads(out.stdout)
+    dur = float(data["format"]["duration"])
+    height = max(int(s.get("height", 0)) for s in data.get("streams", [{}]))
+    return dur, height
+
+
+def probe_youtube(url):
+    out = subprocess.run(
+        ["yt-dlp", "-J", "--no-warnings", url],
+        capture_output=True, text=True, timeout=120,
+    )
+    if out.returncode != 0:
+        raise RuntimeError(out.stderr.strip() or "yt-dlp failed")
+    data = json.loads(out.stdout)
+    dur = float(data.get("duration") or 0)
+    heights = [int(f["height"]) for f in data.get("formats", []) if f.get("height")]
+    return dur, (max(heights) if heights else 0)
+
+
+def check_video(url):
+    is_yt = "youtube.com" in url or "youtu.be" in url
+    tool = "yt-dlp" if is_yt else "ffprobe"
+    if shutil.which(tool) is None:
+        record("input video", "WARN", f"{tool} not on PATH; cannot probe {url}")
+        return
+    try:
+        dur, height = probe_youtube(url) if is_yt else probe_archive_or_direct(url)
+    except Exception as exc:  # noqa: BLE001
+        record("input video", "FAIL", f"not reachable / not probeable: {exc}")
+        return
+    mins = dur / 60.0
+    ok_len = MIN_MINUTES <= mins <= MAX_MINUTES
+    ok_res = height >= MIN_HEIGHT
+    status = "PASS" if (ok_len and ok_res) else "FAIL"
+    record("input video", status,
+           f"{mins:.1f} min (need {MIN_MINUTES}-{MAX_MINUTES}), "
+           f"{height}p (need >= {MIN_HEIGHT}p)")
+
+
+def check_structure(task_dir):
+    missing = [f for f in REQUIRED_FILES if not (Path(task_dir) / f).is_file()]
+    if missing:
+        record("task structure", "FAIL", "missing: " + ", ".join(missing))
+    else:
+        record("task structure", "PASS", "all required files present")
+
+
+def check_calibration(oracle, baseline, agent):
+    if oracle is not None:
+        try:
+            r = read_reward(oracle)
+            record("oracle == 1.0", "PASS" if r >= ORACLE_MIN else "FAIL", f"reward = {r}")
+        except Exception as exc:  # noqa: BLE001
+            record("oracle == 1.0", "FAIL", f"unreadable: {exc}")
+    if baseline is not None:
+        try:
+            r = read_reward(baseline)
+            record("baseline ~ 0", "PASS" if r <= BASELINE_MAX else "FAIL",
+                   f"reward = {r} (need <= {BASELINE_MAX})")
+        except Exception as exc:  # noqa: BLE001
+            record("baseline ~ 0", "FAIL", f"unreadable: {exc}")
+    if agent is not None:
+        try:
+            r = read_reward(agent)
+            record(f"strong agent < {AGENT_MAX}", "PASS" if r < AGENT_MAX else "FAIL",
+                   f"reward = {r} (need < {AGENT_MAX})")
+        except Exception as exc:  # noqa: BLE001
+            record("strong agent < 0.5", "FAIL", f"unreadable: {exc}")
+
+
+def check_rollout(turns):
+    if turns is None:
+        return
+    record("rollout > 50 turns", "PASS" if turns > MIN_TURNS else "FAIL",
+           f"{turns} tool-call turns (need > {MIN_TURNS})")
+
+
+# Anti-shortcut ablations: a strong model run under each degraded input must score
+# near the null baseline. If it scores well, the task has a shortcut (one frame, one
+# modality, recall, or a guessable schema carries the answer).
+ABLATION_MAX = 0.15
+ABLATIONS = {
+    "single_frame": "one representative frame only",
+    "video_only": "video with audio stripped",
+    "audio_only": "audio only",
+    "no_media": "prompt + schema, no media (recall/guess check)",
+    "frame_dump_no_tools": "all frames pasted, no tool use (agency check)",
+}
+
+
+def check_ablations(paths):
+    for key, desc in ABLATIONS.items():
+        path = paths.get(key)
+        if path is None:
+            continue
+        name = f"ablation {key} ~ 0"
+        try:
+            r = read_reward(path)
+            record(name, "PASS" if r <= ABLATION_MAX else "FAIL",
+                   f"reward = {r} (need <= {ABLATION_MAX}; {desc})")
+        except Exception as exc:  # noqa: BLE001
+            record(name, "FAIL", f"unreadable: {exc}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Check a video-understanding task.")
+    ap.add_argument("--task-dir", help="task directory to structure-check")
+    ap.add_argument("--video-url", help="archive.org/direct mp4 or YouTube URL")
+    ap.add_argument("--oracle-reward", help="reward.json from `--agent oracle`")
+    ap.add_argument("--baseline-reward", help="reward.json from an empty submission")
+    ap.add_argument("--agent-reward", help="reward.json from a strong agent run")
+    ap.add_argument("--agent-turns", type=int,
+                    help="tool-call turns from the strong agent's trajectory")
+    for key, desc in ABLATIONS.items():
+        ap.add_argument(f"--ablation-{key.replace('_', '-')}", dest=f"ablation_{key}",
+                        help=f"reward.json from the '{desc}' ablation run")
+    args = ap.parse_args()
+
+    ablation_paths = {k: getattr(args, f"ablation_{k}") for k in ABLATIONS}
+    if not any([args.task_dir, args.video_url, args.oracle_reward,
+                args.baseline_reward, args.agent_reward, args.agent_turns,
+                *ablation_paths.values()]):
+        ap.error("give at least one thing to check (see --help)")
+
+    if args.task_dir:
+        check_structure(args.task_dir)
+    if args.video_url:
+        check_video(args.video_url)
+    check_calibration(args.oracle_reward, args.baseline_reward, args.agent_reward)
+    check_rollout(args.agent_turns)
+    check_ablations(ablation_paths)
+
+    width = max(len(n) for n, _, _ in results)
+    print()
+    for name, status, message in results:
+        print(f"  [{status:4}] {name.ljust(width)}  {message}")
+    failed = [n for n, s, _ in results if s == "FAIL"]
+    skipped = [n for n, s, _ in results if s in ("SKIP", "WARN")]
+    print()
+    if failed:
+        print(f"FAILED: {len(failed)} check(s): {', '.join(failed)}")
+        sys.exit(1)
+    print("All provided checks passed." + (f" ({len(skipped)} warned/skipped)" if skipped else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/agentic_vbench_understanding/README.md
+++ b/tasks/agentic_vbench_understanding/README.md
@@ -1,0 +1,137 @@
+# AgenticVBench — agentic video understanding
+
+AgenticVBench has several **areas of focus**, and they are parallel, not sequential.
+v1.0 is the **post-production** area (`agentic_vbench_repair`, `_assembly`,
+`_sequencing`, `_repurpose`). This family, `agentic_vbench_understanding`, is the
+**video-understanding** area — the first community-built one. It does not modify the
+frozen v1.0 post-production tasks; it stands on its own alongside them.
+
+A task here gives an agent a real video and one unambiguous question, and grades the
+answer with deterministic code. The answer is usually objective — a count, an event,
+a time span, a yes/no — so scoring is clean and the task resists contamination.
+
+## Hard requirements (enforced by `tools/check_task.py`)
+
+Every task in this family must satisfy all of these, and ships a filled-in **Spec
+Card** (`TASK_SPEC.md`; copy it into your task folder as `SPEC.md`) stating each
+claim so a reviewer can verify it.
+
+- **Input video.** Real footage from a stable, downloadable source (archive.org or
+  YouTube). Single-video tasks 10–300 minutes; a two-clip comparison task is exempt
+  from the length floor. At least 720p either way. Bake it at build time with a
+  pinned URL and a SHA256 checksum.
+- **Task prompt.** One clearly worded question with an explicit JSON output schema.
+  No trick wording, no hidden requirements. Define every scored term; give any closed
+  vocabulary in full; name the deliverable path; never leak the scoring method or the
+  ground-truth source.
+- **Scorer.** Deterministic code only (Python stdlib, or a small CV model). No VLM or
+  LLM judge. Strict enough that guessing scores about 0.
+- **Calibration (measured, not claimed).** Oracle scores 1.0; an empty/null
+  submission ≤ 0.10; a strong current agent < 0.10; a real attempt takes > 50
+  tool-call turns.
+- **No shortcuts (ablation gate).** Under each degraded input a strong model must
+  score ≤ 0.15: single frame; video-only and audio-only (for audio-visual tasks);
+  no media at all (catches recall and guessable schemas); all-frames-pasted with no
+  tools (proves agency matters).
+- **Evidence chain.** The answer depends on at least two far-apart moments (and both
+  modalities where applicable). Prefer understanding/reasoning questions over pure
+  perception. Recall of famous footage and on-screen stat graphics must not be enough.
+- **Ground truth by tier.** machine-truth (official structured records) > logged
+  (the system's own signals) > human-verified (2+ annotators, all occurrence
+  windows). Prefer the highest tier available.
+
+## The worked example
+
+`gsw-cle-2018-finals-g4-three-point-timeline/` is a complete, calibrated task built to
+the v1.0 Harbor layout. It bakes the full broadcast of 2018 NBA Finals Game 4 (1080p,
+155 min, archive.org) and asks the agent to reconstruct the timeline of all 22 made
+three-pointers — quarter, game clock, shooter, assister — scored by pure-stdlib F1.
+Measured with headless Claude (Opus 4.8):
+
+| check | result |
+|---|---|
+| input video | 1080p, 155 min (URL + SHA256 pinned) |
+| oracle | 1.0 |
+| empty / null | 0.0 |
+| 22-entry guess | 0.0 |
+| **strong agent (Opus 4.8)** | **0.0465** (2 of 22 threes fully reconstructed) |
+| rollout | 78 tool-call turns |
+
+An earlier version asked for the box score and a strong agent scored 0.64 by recalling
+the famous game and reading on-screen graphics; the timeline redesign killed both
+shortcuts. Prefer less-famous footage anyway.
+
+## Task layout
+
+```
+tasks/agentic_vbench_understanding/<task-id>/
+├── SPEC.md                       # the filled-in Spec Card (copy of TASK_SPEC.md)
+├── task.toml                     # settings, resources, time limits, canary header
+├── environment/Dockerfile        # base image + pinned deps; bakes the media
+└── steps/solve/
+    ├── instruction.md            # what the agent reads + where to save output
+    ├── solution/solve.sh         # the oracle (works out the answer)
+    └── tests/{judge.py, test.sh} # deterministic scorer; writes reward.json
+```
+
+### Task naming
+
+There are no sub-domain folders — every task sits directly under
+`agentic_vbench_understanding/`, so the **task id must be self-describing**. Use
+lowercase words joined by hyphens, and lead with the subject so related tasks sort
+together:
+
+```
+<subject>-<what-the-answer-reconstructs>
+```
+
+Examples:
+
+- `gsw-cle-2018-finals-g4-three-point-timeline` — a specific NBA game; the timeline of made threes
+- `pickplace-grasp-release-timeline` — a robotics pick-and-place; grasp and release events
+- `witcher3-weapon-clipping-bug` — a Witcher 3 clip; the weapon-clipping bug and its window
+
+Keep the id stable once the task merges — downstream tooling resolves tasks by id,
+not by path.
+
+## How to contribute (open a PR)
+
+Read `TASK_SPEC.md`, then propose your idea first (in the community proposal agent or a
+Task Proposal issue) so a maintainer can sanity-check the difficulty and long-horizon
+fit before you build. Then:
+
+1. **Build the task** — a real pinned video, the instruction prompt, the oracle, and the
+   deterministic verifier (`tests/judge.py` + `test.sh`).
+2. **Validate** with the checker:
+
+   ```bash
+   python3 scripts/understanding/check_task.py \
+     --task-dir tasks/agentic_vbench_understanding/<task-id> \
+     --video-url "<archive.org or youtube url>" \
+     --oracle-reward <reward.json> --baseline-reward <reward.json> \
+     --agent-reward <reward.json> --agent-turns <n> \
+     --ablation-no-media <reward.json> --ablation-single-frame <reward.json> ...
+   ```
+
+3. **Calibrate against three agents.** Run the task end to end with **Antigravity**,
+   **Codex CLI**, and **Claude Code CLI**, gather each agent's rollout, and grade it.
+   Iterate on the prompt and verifier until the scores land below the 0.10 bar and the
+   rollouts run long (> 50 tool-call turns). Keep the rollouts and a scores table under
+   `<task-id>/calibration/` (one transcript per agent, plus `scores.md`).
+
+4. **Open a PR** into `main` adding `tasks/agentic_vbench_understanding/<task-id>/`. The
+   PR must include:
+   - the **task prompt** (`steps/solve/instruction.md`),
+   - the **verifier** (`steps/solve/tests/`) and the oracle (`steps/solve/solution/`),
+   - the **agent rollouts** and the **scores for all three agents** (Antigravity, Codex,
+     Claude Code), with rollout turn counts,
+   - the filled `SPEC.md`.
+
+A reviewer checks the PR against the requirements above, re-runs the oracle and a strong
+agent, and reads the run for shortcuts before merging.
+
+## To finish wiring the area
+
+- [x] Register `agentic_vbench_understanding` in `scripts/_task_paths.py`.
+- [ ] Backfill `SPEC.md` for the worked example.
+- [ ] Add more calibrated tasks (a cross-modal audio+video task is the biggest gap).

--- a/tasks/agentic_vbench_understanding/README.md
+++ b/tasks/agentic_vbench_understanding/README.md
@@ -6,9 +6,10 @@ v1.0 is the **post-production** area (`agentic_vbench_repair`, `_assembly`,
 **video-understanding** area — the first community-built one. It does not modify the
 frozen v1.0 post-production tasks; it stands on its own alongside them.
 
-A task here gives an agent a real video and one unambiguous question, and grades the
-answer with deterministic code. The answer is usually objective — a count, an event,
-a time span, a yes/no — so scoring is clean and the task resists contamination.
+A task here gives an agent one or multiple real videos and one unambiguous question,
+and grades the answer with deterministic code. The answer is usually objective — a
+count, an event, a time span, a yes/no — so scoring is clean and the task resists
+contamination.
 
 ## Hard requirements (enforced by `tools/check_task.py`)
 
@@ -16,10 +17,11 @@ Every task in this family must satisfy all of these, and ships a filled-in **Spe
 Card** (`TASK_SPEC.md`; copy it into your task folder as `SPEC.md`) stating each
 claim so a reviewer can verify it.
 
-- **Input video.** Real footage from a stable, downloadable source (archive.org or
-  YouTube). Single-video tasks 10–300 minutes; a two-clip comparison task is exempt
-  from the length floor. At least 720p either way. Bake it at build time with a
-  pinned URL and a SHA256 checksum.
+- **Input video(s).** One or more real videos from a stable, downloadable source
+  (archive.org or YouTube). A single-video task runs 10–300 minutes; a comparison
+  task may instead use a pair (or a few) short clips, which are exempt from the
+  length floor. At least 720p either way. Bake each at build time with a pinned URL
+  and a SHA256 checksum.
 - **Task prompt.** One clearly worded question with an explicit JSON output schema.
   No trick wording, no hidden requirements. Define every scored term; give any closed
   vocabulary in full; name the deliverable path; never leak the scoring method or the
@@ -68,10 +70,13 @@ tasks/agentic_vbench_understanding/<task-id>/
 ├── SPEC.md                       # the filled-in Spec Card (copy of TASK_SPEC.md)
 ├── task.toml                     # settings, resources, time limits, canary header
 ├── environment/Dockerfile        # base image + pinned deps; bakes the media
-└── steps/solve/
-    ├── instruction.md            # what the agent reads + where to save output
-    ├── solution/solve.sh         # the oracle (works out the answer)
-    └── tests/{judge.py, test.sh} # deterministic scorer; writes reward.json
+├── steps/solve/
+│   ├── instruction.md            # what the agent reads + where to save output
+│   ├── solution/solve.sh         # the oracle (works out the answer)
+│   └── tests/{judge.py, test.sh} # deterministic scorer; writes reward.json
+└── calibration/                  # the difficulty evidence (see below)
+    ├── scores.md                 # per-agent score + rollout turns table
+    └── rollouts/                 # one raw agent transcript per agent
 ```
 
 ### Task naming

--- a/tasks/agentic_vbench_understanding/TASK_SPEC.md
+++ b/tasks/agentic_vbench_understanding/TASK_SPEC.md
@@ -1,0 +1,92 @@
+---
+title: Task Spec Card
+summary: The structured header every video-understanding task must fill in and prove.
+read_when: Authoring a task. Copy this file into your task folder and fill every field.
+---
+
+# Task Spec Card
+
+Copy this file into your task folder as `SPEC.md` and fill in every field. A reviewer
+checks the card against the task; the checker (`tools/check_task.py`) verifies the
+measurable parts. A task with an incomplete card does not enter review.
+
+The card exists because "a good task" is easy to claim and hard to check. Each field
+forces one concrete claim that can be verified.
+
+```yaml
+task: <family>/<task-id>
+
+# 1. What kind of thinking does this task need?
+#    perception = find/count/time events. understanding = compare, order, relate.
+#    reasoning = cause, prediction, cross-event inference. Prefer understanding or
+#    reasoning; pure perception must be very hard to justify itself.
+cognitive_level: perception | understanding | reasoning
+
+# 2. Which modalities are REQUIRED (not just present)? One line each on why the
+#    answer cannot be produced without it.
+modalities_required:
+  video: <why video is necessary>
+  audio: <why audio is necessary, or "not used">
+
+# 3. The exact question the agent is asked (one task, no ambiguity), and the exact
+#    output schema it fills in.
+question: <one sentence>
+output_schema: <the JSON shape, with units and tolerances>
+
+# 4. Evidence chain: the specific moments (and modalities) the answer depends on.
+#    A good task needs at least two far-apart moments; a single lookup is too easy.
+evidence:
+  - <t=..s, modality, what it contributes>
+  - <t=..s, modality, what it contributes>
+
+# 5. Ground truth: value, source, tier, and how it was verified.
+#    machine-truth  = official structured record (league play-by-play, game logs)
+#    logged         = the system's own recorded signals (robot proprioception, FK)
+#    human-verified = perceptual judgment; requires 2+ independent annotators and
+#                     ALL occurrence windows annotated
+ground_truth:
+  source: <where the answer key comes from>
+  tier: machine-truth | logged | human-verified
+  verification: <the cross-check you ran, e.g. "PBP-derived 3PM equals box-score 3PM
+                 for all 10 shooters" or "FK ee-height curve matches gripper events">
+
+# 6. Scorer: deterministic code only. State the metric and the anchors.
+scorer:
+  metric: <e.g. F1 over events; a TP requires X, Y, Z within tolerance T>
+  oracle_reward: 1.0
+  null_reward: <measured, must be <= 0.10>
+
+# 7. Difficulty: measured with a real strong-agent run.
+difficulty:
+  strong_agent_reward: <measured, must be < 0.10>
+  tool_call_turns: <measured, must be > 50>
+  agent_model: <which model/harness>
+
+# 8. Anti-shortcut ablations: run a strong model under each degraded input.
+#    Every one must score near the null baseline (<= 0.15). If any scores well,
+#    the task has a shortcut - fix the task, not the threshold.
+anti_shortcut:
+  single_frame: <reward with one representative frame only>
+  video_only: <reward with video, audio stripped>   # for audio-visual tasks
+  audio_only: <reward with audio only>              # for audio-visual tasks
+  no_media: <reward with prompt+schema only - catches recall and guessable schemas>
+  frame_dump_no_tools: <reward with all frames pasted, no tool use - catches tasks
+                        where agency does not actually matter>
+
+# 9. Input media.
+input:
+  url: <archive.org / YouTube / HF url>
+  sha256: <digest of the baked file>
+  length_min: <minutes; 10-300 for single-video tasks, exempt for comparison pairs>
+  resolution: <height; >= 720>
+```
+
+## Prompt-writing rules (the agent-facing instruction)
+
+- One task per task. No compound asks.
+- Define every term the scorer depends on (what counts as a "made three", a "grasp",
+  a "bug occurrence"), and give any closed vocabulary in full.
+- Give the exact output schema, with units and the tolerance the scorer uses.
+- Name the deliverable path explicitly.
+- Never describe the scoring method, weights, or the ground-truth source.
+- No trick wording, no hidden requirements: everything scored is stated.

--- a/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/calibration/rollouts/README.md
+++ b/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/calibration/rollouts/README.md
@@ -1,0 +1,11 @@
+# Rollouts
+
+One raw agent transcript per agent, so a reviewer can confirm the score was earned
+honestly and count the tool-call turns:
+
+- `antigravity.jsonl`
+- `codex.jsonl`
+- `claude-code.jsonl`
+
+Each transcript should show the full run (all tool calls and the final answer). For
+this worked example the transcripts are not checked in; new tasks must include them.

--- a/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/calibration/scores.md
+++ b/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/calibration/scores.md
@@ -1,0 +1,21 @@
+# Calibration — gsw-cle-2018-finals-g4-three-point-timeline
+
+Deterministic F1 scorer (`steps/solve/tests/judge.py`). A task clears the bar when
+**every real agent scores below 0.10** and a real attempt takes **more than 50
+tool-call turns**. Oracle must be 1.0 and an empty attempt near 0.
+
+| run | score | rollout (tool-call turns) |
+|---|---|---|
+| oracle | 1.0 | — |
+| empty / null | 0.0 | — |
+| 22-entry guess | 0.0 | — |
+| Antigravity | _to run_ | _to run_ |
+| Codex CLI | _to run_ | _to run_ |
+| Claude Code CLI (Opus 4.8) | 0.0465 | 78 |
+
+Raw transcripts are in `rollouts/` — one file per agent, so a reviewer can confirm
+each score was earned honestly and count the tool-call turns.
+
+Note: this worked example predates the three-agent requirement and was originally
+calibrated with a single headless Claude run (recorded above as the Claude Code CLI
+row). New tasks must fill in all three agents.

--- a/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/environment/Dockerfile
+++ b/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/environment/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# The agent uses ffmpeg/ffprobe to seek and sample frames. The grader is pure
+# stdlib (it only compares integers), so it needs nothing extra.
+
+# Bake the full-game broadcast at build time, the same way the v1.0 families do,
+# with a pinned URL and a SHA256 verified at build (see the repo's sequencing
+# Dockerfile for the pattern).
+#
+# TODO before this is a real task:
+#   1. Re-host the archive.org file on Hugging Face (or pin the direct archive.org
+#      file URL) so the bytes are stable, and put the exact URL here.
+#   2. (DONE) The exact archive.org file URL is set below. SHA256 is filled in once
+#      the file finishes downloading and is hashed.
+ARG MATERIALS_URL=https://archive.org/download/2018-nba-finals-game-4-cleveland-cavaliers-vs-golden-state-warriors-jun-8-2018/2018%20NBA%20Finals%20Game%204%20Cleveland%20Cavaliers%20vs%20Golden%20State%20Warriors%20Jun%208%20%202018.mp4
+ARG MATERIALS_SHA256=6df565f0708a9a6b0f80c2b02bcb7d5211e48abd234d752cf607525adcb30757
+RUN mkdir -p /baked \
+ && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+      "$MATERIALS_URL" -o /baked/game.mp4 \
+ && echo "${MATERIALS_SHA256}  /baked/game.mp4" | sha256sum -c - \
+ && test -s /baked/game.mp4
+
+WORKDIR /workspace
+RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/steps/solve/instruction.md
+++ b/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/steps/solve/instruction.md
@@ -1,0 +1,37 @@
+# Three-Point Timeline Reconstruction
+
+You are given one video at `/workspace/materials/game.mp4`: the full broadcast of an
+NBA game (Golden State Warriors vs Cleveland Cavaliers). Reconstruct the complete
+timeline of every made three-point field goal in the game, by either team.
+
+For each made three, report the quarter, the game clock at the moment it was made,
+who made it, and who assisted it (or `unassisted`). Use any tools in the image (for
+example `ffmpeg` and `ffprobe`) to seek through and sample the video. The on-screen
+score-and-clock graphic, the players' jerseys, and the play action are your evidence.
+
+## What to submit
+
+Write `/workspace/output/solution.json` in exactly this shape:
+
+```json
+{
+  "three_pointers": [
+    {"quarter": 1, "clock": "11:02", "shooter": "JR Smith",      "assister": "LeBron James"},
+    {"quarter": 1, "clock": "8:47",  "shooter": "Stephen Curry", "assister": "unassisted"}
+  ]
+}
+```
+
+- One entry per made three-pointer, in any order.
+- `quarter`: 1 to 4.
+- `clock`: the game clock shown when the shot was made, as on the broadcast (`mm:ss`,
+  or seconds when under a minute).
+- `shooter`: the player's full name (first and last).
+- `assister`: the assisting player's full name, or `unassisted`.
+
+## Rules
+
+- Stay inside this working directory. Do not read, write, or search outside it.
+- Do not look anything up online, and do not rely on memory of this game; find every
+  shot in the video.
+- Count only made three-pointers, not attempts, not two-pointers, not free throws.

--- a/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/steps/solve/solution/solve.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Oracle: write the verified three-point timeline as solution.json.
+#
+# The reference answer is the official play-by-play (from ESPN's structured feed for
+# this game): every made three-pointer with quarter, game clock, shooter, assister.
+# Like the Assembly oracle, this is the verified answer key, not an echo of the input.
+# The agent never sees this file.
+set -euo pipefail
+
+mkdir -p /workspace/output
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+THREES = [
+  {"quarter": 1, "clock": "11:02", "shooter": "JR Smith",       "assister": "LeBron James"},
+  {"quarter": 1, "clock": "8:47",  "shooter": "Stephen Curry",  "assister": "unassisted"},
+  {"quarter": 1, "clock": "6:38",  "shooter": "Kevin Love",     "assister": "LeBron James"},
+  {"quarter": 1, "clock": "6:25",  "shooter": "Andre Iguodala", "assister": "Draymond Green"},
+  {"quarter": 1, "clock": "6:03",  "shooter": "Stephen Curry",  "assister": "unassisted"},
+  {"quarter": 1, "clock": "5:42",  "shooter": "Draymond Green", "assister": "Kevin Durant"},
+  {"quarter": 1, "clock": "3:59",  "shooter": "Kevin Love",     "assister": "Jeff Green"},
+  {"quarter": 1, "clock": "2:39",  "shooter": "Nick Young",     "assister": "Kevin Durant"},
+  {"quarter": 1, "clock": "1:35",  "shooter": "Andre Iguodala", "assister": "Jordan Bell"},
+  {"quarter": 2, "clock": "11:36", "shooter": "Jeff Green",     "assister": "Larry Nance Jr."},
+  {"quarter": 2, "clock": "4:36",  "shooter": "Andre Iguodala", "assister": "Draymond Green"},
+  {"quarter": 2, "clock": "3:54",  "shooter": "JR Smith",       "assister": "LeBron James"},
+  {"quarter": 2, "clock": "3:12",  "shooter": "Stephen Curry",  "assister": "unassisted"},
+  {"quarter": 2, "clock": "1:20",  "shooter": "JR Smith",       "assister": "LeBron James"},
+  {"quarter": 2, "clock": "5.0",   "shooter": "Stephen Curry",  "assister": "Kevin Durant"},
+  {"quarter": 3, "clock": "5:52",  "shooter": "Klay Thompson",  "assister": "Kevin Durant"},
+  {"quarter": 3, "clock": "4:58",  "shooter": "Rodney Hood",    "assister": "LeBron James"},
+  {"quarter": 3, "clock": "2:12",  "shooter": "Klay Thompson",  "assister": "Kevin Durant"},
+  {"quarter": 4, "clock": "11:11", "shooter": "Stephen Curry",  "assister": "Draymond Green"},
+  {"quarter": 4, "clock": "10:01", "shooter": "George Hill",    "assister": "Larry Nance Jr."},
+  {"quarter": 4, "clock": "9:45",  "shooter": "Stephen Curry",  "assister": "unassisted"},
+  {"quarter": 4, "clock": "6:19",  "shooter": "Stephen Curry",  "assister": "Draymond Green"},
+]
+
+Path("/workspace/output/solution.json").write_text(json.dumps({"three_pointers": THREES}, indent=2))
+PY
+
+echo "oracle: wrote /workspace/output/solution.json (22 threes)"

--- a/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/steps/solve/tests/judge.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Grade a three-point-timeline reconstruction. Pure Python stdlib, deterministic.
+
+The agent must list every made three-pointer with quarter, game clock, shooter, and
+assister. A predicted three is a true positive only when it FULLY reconstructs the
+play: same quarter, same shooter, same assister, and a game clock within TOL seconds.
+We then score by F1 (so misses and false positives both hurt). reward = F1.
+
+Why this task and metric: a full game has ~20 made threes scattered across 2.5 hours.
+No broadcast graphic lists them, no one memorizes their timestamps, and identifying
+the passer on each one requires watching the play, so only genuinely reconstructing
+the game off the video scores. The oracle (exact list) -> 1.0; an empty or guessed
+list -> ~0; a strong agent that mostly mis-attributes shooters/assisters -> well
+below 0.1.
+"""
+import argparse
+import json
+import re
+from pathlib import Path
+
+TOL = 5  # seconds of game-clock tolerance (the broadcast clock is exact; reads should be close)
+
+GROUND_TRUTH = [
+  {"quarter": 1, "clock": "11:02", "shooter": "JR Smith",       "assister": "LeBron James"},
+  {"quarter": 1, "clock": "8:47",  "shooter": "Stephen Curry",  "assister": "unassisted"},
+  {"quarter": 1, "clock": "6:38",  "shooter": "Kevin Love",     "assister": "LeBron James"},
+  {"quarter": 1, "clock": "6:25",  "shooter": "Andre Iguodala", "assister": "Draymond Green"},
+  {"quarter": 1, "clock": "6:03",  "shooter": "Stephen Curry",  "assister": "unassisted"},
+  {"quarter": 1, "clock": "5:42",  "shooter": "Draymond Green", "assister": "Kevin Durant"},
+  {"quarter": 1, "clock": "3:59",  "shooter": "Kevin Love",     "assister": "Jeff Green"},
+  {"quarter": 1, "clock": "2:39",  "shooter": "Nick Young",     "assister": "Kevin Durant"},
+  {"quarter": 1, "clock": "1:35",  "shooter": "Andre Iguodala", "assister": "Jordan Bell"},
+  {"quarter": 2, "clock": "11:36", "shooter": "Jeff Green",     "assister": "Larry Nance Jr."},
+  {"quarter": 2, "clock": "4:36",  "shooter": "Andre Iguodala", "assister": "Draymond Green"},
+  {"quarter": 2, "clock": "3:54",  "shooter": "JR Smith",       "assister": "LeBron James"},
+  {"quarter": 2, "clock": "3:12",  "shooter": "Stephen Curry",  "assister": "unassisted"},
+  {"quarter": 2, "clock": "1:20",  "shooter": "JR Smith",       "assister": "LeBron James"},
+  {"quarter": 2, "clock": "5.0",   "shooter": "Stephen Curry",  "assister": "Kevin Durant"},
+  {"quarter": 3, "clock": "5:52",  "shooter": "Klay Thompson",  "assister": "Kevin Durant"},
+  {"quarter": 3, "clock": "4:58",  "shooter": "Rodney Hood",    "assister": "LeBron James"},
+  {"quarter": 3, "clock": "2:12",  "shooter": "Klay Thompson",  "assister": "Kevin Durant"},
+  {"quarter": 4, "clock": "11:11", "shooter": "Stephen Curry",  "assister": "Draymond Green"},
+  {"quarter": 4, "clock": "10:01", "shooter": "George Hill",    "assister": "Larry Nance Jr."},
+  {"quarter": 4, "clock": "9:45",  "shooter": "Stephen Curry",  "assister": "unassisted"},
+  {"quarter": 4, "clock": "6:19",  "shooter": "Stephen Curry",  "assister": "Draymond Green"},
+]
+
+
+def norm(s):
+    return re.sub(r"[^a-z]", "", str(s).lower())
+
+
+def clock_secs(cv):
+    cv = str(cv).strip()
+    try:
+        if ":" in cv:
+            m, s = cv.split(":")
+            return int(m) * 60 + int(float(s))
+        return int(float(cv))
+    except (ValueError, AttributeError):
+        return None
+
+
+# Lastnames that are unique among GT shooters can be matched on lastname alone;
+# ambiguous ones (e.g. two "Green"s) require the full name to match.
+def _lastname(name):
+    return norm(name.split()[-1]) if str(name).split() else norm(name)
+
+
+_GT_LASTS = [_lastname(g["shooter"]) for g in GROUND_TRUTH]
+_UNIQUE_LASTS = {ln for ln in _GT_LASTS if _GT_LASTS.count(ln) == 1}
+
+
+def shooter_match(pred, gt_full):
+    p, g = norm(pred), norm(gt_full)
+    if not p:
+        return False
+    if p == g:
+        return True
+    gl = _lastname(gt_full)
+    return gl in _UNIQUE_LASTS and p == gl  # lastname only if unambiguous
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--solution", required=True, type=Path)
+    ap.add_argument("--reward-json", required=True, type=Path)
+    ap.add_argument("--reward-txt", required=True, type=Path)
+    args = ap.parse_args()
+
+    reason = "ok"
+    preds = []
+    try:
+        sol = json.loads(args.solution.read_text())
+        preds = sol.get("three_pointers", [])
+        if not isinstance(preds, list):
+            raise ValueError("three_pointers is not a list")
+    except Exception as exc:  # noqa: BLE001 - malformed output scores 0
+        reason, preds = f"unreadable solution.json: {exc}", []
+
+    used = [False] * len(GROUND_TRUTH)      # for strict (full-play) TPs
+    used_loose = [False] * len(GROUND_TRUTH)  # shooter+time only, for diagnostics
+    tp = 0
+    shooter_time_only = 0
+    for pr in preds:
+        if not isinstance(pr, dict):
+            continue
+        pq = pr.get("quarter")
+        ps = clock_secs(pr.get("clock"))
+        if ps is None:
+            continue
+        # diagnostic: did it at least get quarter+shooter+clock right?
+        for i, gt in enumerate(GROUND_TRUTH):
+            if not used_loose[i] and pq == gt["quarter"] \
+                    and shooter_match(pr.get("shooter", ""), gt["shooter"]) \
+                    and abs(ps - clock_secs(gt["clock"])) <= TOL:
+                used_loose[i] = True
+                shooter_time_only += 1
+                break
+        # scored: full-play reconstruction (also requires the assister)
+        for i, gt in enumerate(GROUND_TRUTH):
+            if not used[i] and pq == gt["quarter"] \
+                    and shooter_match(pr.get("shooter", ""), gt["shooter"]) \
+                    and norm(pr.get("assister", "")) == norm(gt["assister"]) \
+                    and abs(ps - clock_secs(gt["clock"])) <= TOL:
+                used[i] = True
+                tp += 1
+                break
+
+    n_pred, n_gt = len(preds), len(GROUND_TRUTH)
+    precision = tp / n_pred if n_pred else 0.0
+    recall = tp / n_gt if n_gt else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+
+    details = {
+        "reason": reason,
+        "n_ground_truth": n_gt,
+        "n_predicted": n_pred,
+        "true_positives_full_play": tp,
+        "shooter_time_only_matches": shooter_time_only,
+        "precision": round(precision, 4),
+        "recall": round(recall, 4),
+        "f1": round(f1, 4),
+        "clock_tolerance_s": TOL,
+    }
+    args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    args.reward_json.write_text(json.dumps({"reward": round(f1, 4), "details": details}, indent=2))
+    args.reward_txt.write_text(f"{round(f1, 4)}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/steps/solve/tests/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Verifier entry point. Preserve the agent's output for the audit trail, then grade.
+set -euo pipefail
+
+mkdir -p /logs/verifier /logs/artifacts
+
+if [ -d /workspace/output ]; then
+    cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
+fi
+
+python3 /tests/judge.py \
+        --solution /workspace/output/solution.json \
+        --reward-json /logs/verifier/reward.json \
+        --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/steps/solve/workdir/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Pre-agent stage: copy the pre-baked broadcast into the agent's workspace.
+set -euo pipefail
+
+mkdir -p /workspace/materials /workspace/output /workspace/work
+cp /baked/game.mp4 /workspace/materials/game.mp4
+
+mkdir -p /logs/artifacts
+ls -la /workspace/materials/ > /logs/artifacts/materials-listing.txt
+
+rm -- "$0"

--- a/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/task.toml
+++ b/tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/task.toml
@@ -1,0 +1,34 @@
+version = "1.0"
+
+[task]
+name = "agentic-vbench/gsw-cle-2018-finals-g4-three-point-timeline"
+
+[metadata]
+difficulty = "hard"
+category = "video-understanding"
+tags = ["video-understanding", "sports-analytics", "basketball", "event-timeline", "agentic-vbench-sports"]
+# Full broadcast, 2018 NBA Finals Game 4 (CLE @ GSW, 2018-06-08), from archive.org.
+# Ground truth: official box score (cross-checked on ESPN and Basketball-Reference).
+source = "archive.org: 2018-nba-finals-game-4-cleveland-cavaliers-vs-golden-state-warriors-jun-8-2018"
+
+[environment]
+build_timeout_sec = 2400.0
+cpus = 4
+memory_mb = 8192
+# A full ~2.5h broadcast is several GB; give the build and trial room.
+storage_mb = 16384
+# The clip is baked at build time and the answer is not online: keep this false.
+allow_internet = false
+
+[environment.env]
+HF_TOKEN = "${HF_TOKEN:-}"
+
+[[steps]]
+name = "solve"
+
+[steps.agent]
+# A full game is long: give the agent real time to sample and tally.
+timeout_sec = 3600.0
+
+[steps.verifier]
+timeout_sec = 600.0


### PR DESCRIPTION
**Draft — for discussion, not merge yet.**

Adds a new task family `agentic_vbench_understanding` alongside the frozen v1.0
post-production families. Nothing in the post-production tasks is touched.

### What's here
- `tasks/agentic_vbench_understanding/README.md` — hard requirements, the worked
  example's measured calibration, task layout, and the PR/submission bundle
  (task prompt, verifier, oracle, and calibration evidence: agent rollouts +
  scores for **Antigravity**, **Codex CLI**, and **Claude Code CLI**, showing a
  strong agent < 0.10 over > 50 tool-call turns).
- `tasks/agentic_vbench_understanding/TASK_SPEC.md` — the Spec Card template.
- `tasks/agentic_vbench_understanding/gsw-cle-2018-finals-g4-three-point-timeline/`
  — the calibrated worked example (Opus 4.8: 0.0465 over 78 turns).
- `scripts/understanding/check_task.py` — the checker for the requirements.
- `scripts/_task_paths.py` — registers the family (fifth entry).