### PR TITLE
Super Bowl LI referee-announced player-foul timeline task

### DIFF
--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/PROVENANCE.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/PROVENANCE.md
@@ -85,20 +85,21 @@ carry a player jersey number, by rule/convention:
 | 3 | 2:06 | NE | illegal touching (kick) | S. Gostkowski | 3 | kicking-team touching — announced without a player number |
 | 3 | 0:04 | ATL | delay of game | M. Bosher | 5 | team foul — no player number |
 
-## Open design questions (for the PR / issue #60)
-- **Declined fouls (rows 2, 3, 8):** included because the scope rule says the referee
-  announces the number regardless of the penalty decision. That assumption is verified
-  by transcription for 0 of these 3 rows so far (see the audio-verified column above) —
-  still open until confirmed the same way the 4 accepted rows were.
-- **Event count:** 13 natural events (16 total referee-mic penalty announcements, minus
-  3 with no jersey number). Reaching the ≥20 figure from review ask #4 would require
-  adding replay reviews and/or measurements, but this game has at most 1 review and no
-  measurements (see enumeration table above), and neither carries a jersey number or an
-  audio-only component — padding with them would dilute the audio/video seam rather than
-  extend it. Recommendation: keep the ~13-event scope and address the F1 fragility
-  (review ask #4's "single lucky guess clears 0.10" concern) as a scoring-shape question
-  instead of an event-count question.
-- **Clock precision:** superseded by the observable clock rule above (per review ask #5)
-  — clocks are the official Game Book values, scorer tolerance ±5 s, 3 of 13 rows
-  spot-checked against the score bug by frame extraction; full per-row audit against the
-  rule is open.
+## Scope and scoring ruling (settled by techgenmini on issue #60)
+- **Scope:** keep the natural ~13 referee-announced player-foul events. Do not pad with
+  replay reviews or measurements — they carry no jersey number and no audio-only
+  component in this game, so adding them would dilute the audio/video seam rather than
+  extend it.
+- **Declined fouls (rows 2, 3, 8):** stay in scope only if each one's number is
+  individually confirmed audible. Verified by transcription for 0 of these 3 rows so
+  far (see the audio-verified column above) — pending, per-row, not a blanket rule
+  anymore.
+- **Scoring:** F1 replaced with F2 (β=2, recall-weighted) in `judge.py` — a single lucky
+  exact row no longer clears the 0.10 anti-shortcut gate (F1 gave 0.1429; F2 gives
+  0.0943). Regression-checked against null/one-hit/two-hit/oracle in
+  `steps/solve/tests/test_regressions.py`.
+- **Clock rule:** the observable rule above (last score-bug frame before the
+  announcement) is now the binding definition. Scorer tolerance stays ±5 s. 3 of 13 rows
+  were spot-checked against the score bug by frame extraction during initial design;
+  the full per-row observability audit against this rule — for all 13 rows, alongside
+  each row's audio timestamp/transcript and the Game Book clock — is still pending.

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/PROVENANCE.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/PROVENANCE.md
@@ -1,0 +1,54 @@
+# Ground-truth provenance — Super Bowl LI penalty timeline
+
+## Sources
+- **Penalty list + game clocks:** official NFL Game Book play-by-play for Super Bowl LI
+  (NE 34–28 ATL, 2017-02-05). Cross-checked against nflpenalties.com (13 accepted
+  penalties, 88 yards; 16 flags total).
+- **Jersey numbers:** the same Game Book's Lineups and Substitutions section (authoritative
+  official roster). No jersey number is taken from memory or inference.
+- **Independent audio confirmation:** four fouls had their referee-announced number verified
+  by transcribing the broadcast audio — #23 R. Alford, #34 B. Poole, #70 J. Matthews,
+  #59 D. Campbell. All four matched the official lineup.
+
+## Scope rule (mechanical)
+A **scored event** is any penalty in the Game Book play-by-play whose infraction is an
+**individual player foul that the referee announces with a jersey number** — whether the
+penalty was accepted or declined (the referee announces the number either way). The jersey
+number is the player's number in the official Game Book lineup.
+
+## The 13 scored fouls
+| # | Q | clock | team | type | player | № | accepted? |
+|---|---|-------|------|------|--------|---|-----------|
+| 1 | 1 | 13:47 | ATL | offensive holding | P. Worrilow | 55 | yes |
+| 2 | 2 | 14:19 | NE | offensive holding | M. Bennett | 88 | declined |
+| 3 | 2 | 8:55 | NE | defensive pass interference | P. Chung | 23 | declined |
+| 4 | 2 | 8:02 | ATL | defensive holding | R. Alford | 23 | yes (audio ✓) |
+| 5 | 2 | 6:10 | ATL | defensive holding | B. Poole | 34 | yes |
+| 6 | 2 | 5:16 | ATL | defensive holding | B. Poole | 34 | yes (audio ✓) |
+| 7 | 2 | 0:18 | NE | offensive holding | M. Bennett | 88 | yes |
+| 8 | 3 | 13:02 | NE | offensive pass interference | C. Hogan | 15 | declined |
+| 9 | 3 | 8:43 | NE | defensive pass interference | M. Butler | 21 | yes |
+| 10 | 3 | 1:30 | ATL | offensive holding | J. Matthews | 70 | yes (audio ✓) |
+| 11 | 4 | 3:50 | ATL | offensive holding | J. Matthews | 70 | yes |
+| 12 | 4 | 0:57 | ATL | defensive offside | D. Freeney | 93 | yes |
+| 13 | 5 (OT) | 11:18 | ATL | defensive pass interference | D. Campbell | 59 | yes (audio ✓) |
+
+## Exclusions (documented, per maintainer guidance in issue #60)
+These Game Book penalties are **not scored** because the referee's announcement does not
+carry a player jersey number, by rule/convention:
+
+| Q | clock | team | type | player | № | reason excluded |
+|---|-------|------|------|--------|---|-----------------|
+| 2 | 8:48 | NE | illegal formation | S. McClellin | 58 | formation foul — announced without a player number |
+| 3 | 2:06 | NE | illegal touching (kick) | S. Gostkowski | 3 | kicking-team touching — announced without a player number |
+| 3 | 0:04 | ATL | delay of game | M. Bosher | 5 | team foul — no player number |
+
+## Open design questions (for the PR / issue #60)
+- **Declined fouls (rows 2, 3, 8):** included here because the referee announces the number.
+  If the maintainer prefers accepted-only, dropping them yields 10 events.
+- **Event count:** 13 (vs 22 in the NBA worked example). The maintainer suggested widening to
+  *every* referee announcement including replay reviews and measurements; those carry no jersey
+  number and would need a schema addition, so they are left as a further extension pending
+  agreement rather than silently included.
+- **Clock precision:** clocks are the official Game Book values; the scorer allows ±5 s. Three
+  were additionally confirmed against the on-screen score bug by frame extraction.

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/PROVENANCE.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/PROVENANCE.md
@@ -16,22 +16,64 @@ A **scored event** is any penalty in the Game Book play-by-play whose infraction
 penalty was accepted or declined (the referee announces the number either way). The jersey
 number is the player's number in the official Game Book lineup.
 
+## Clock rule (observable, mirrors `steps/solve/instruction.md`)
+`clock` is the game clock shown in the on-screen score bug on the **last frame it is
+displayed before the referee begins the foul announcement** — not the time the play
+ended, not the down-and-distance display, not any other frame. The score bug is hidden
+during live action and restored between plays, so this rule names one unambiguous frame
+rather than leaving the agent (or the ground-truth author) to choose among several
+plausible displayed times. **Audit status: defined, not yet audited against broadcast
+frames per row.** Three rows (see table) were spot-checked against the score bug by
+frame extraction during initial design; the full per-row audit against this exact rule
+— including a normal accepted foul, a declined foul, and the OT case — is open, per
+issue #60 review ask #5.
+
 ## The 13 scored fouls
-| # | Q | clock | team | type | player | № | accepted? |
-|---|---|-------|------|------|--------|---|-----------|
-| 1 | 1 | 13:47 | ATL | offensive holding | P. Worrilow | 55 | yes |
-| 2 | 2 | 14:19 | NE | offensive holding | M. Bennett | 88 | declined |
-| 3 | 2 | 8:55 | NE | defensive pass interference | P. Chung | 23 | declined |
-| 4 | 2 | 8:02 | ATL | defensive holding | R. Alford | 23 | yes (audio ✓) |
-| 5 | 2 | 6:10 | ATL | defensive holding | B. Poole | 34 | yes |
-| 6 | 2 | 5:16 | ATL | defensive holding | B. Poole | 34 | yes (audio ✓) |
-| 7 | 2 | 0:18 | NE | offensive holding | M. Bennett | 88 | yes |
-| 8 | 3 | 13:02 | NE | offensive pass interference | C. Hogan | 15 | declined |
-| 9 | 3 | 8:43 | NE | defensive pass interference | M. Butler | 21 | yes |
-| 10 | 3 | 1:30 | ATL | offensive holding | J. Matthews | 70 | yes (audio ✓) |
-| 11 | 4 | 3:50 | ATL | offensive holding | J. Matthews | 70 | yes |
-| 12 | 4 | 0:57 | ATL | defensive offside | D. Freeney | 93 | yes |
-| 13 | 5 (OT) | 11:18 | ATL | defensive pass interference | D. Campbell | 59 | yes (audio ✓) |
+| # | Q | clock | team | type | player | № | accepted? | audio-verified? |
+|---|---|-------|------|------|--------|---|-----------|------------------|
+| 1 | 1 | 13:47 | ATL | offensive holding | P. Worrilow | 55 | yes | PENDING |
+| 2 | 2 | 14:19 | NE | offensive holding | M. Bennett | 88 | declined | PENDING |
+| 3 | 2 | 8:55 | NE | defensive pass interference | P. Chung | 23 | declined | PENDING |
+| 4 | 2 | 8:02 | ATL | defensive holding | R. Alford | 23 | yes | ✓ |
+| 5 | 2 | 6:10 | ATL | defensive holding | B. Poole | 34 | yes | PENDING |
+| 6 | 2 | 5:16 | ATL | defensive holding | B. Poole | 34 | yes | ✓ |
+| 7 | 2 | 0:18 | NE | offensive holding | M. Bennett | 88 | yes | PENDING |
+| 8 | 3 | 13:02 | NE | offensive pass interference | C. Hogan | 15 | declined | PENDING |
+| 9 | 3 | 8:43 | NE | defensive pass interference | M. Butler | 21 | yes | PENDING |
+| 10 | 3 | 1:30 | ATL | offensive holding | J. Matthews | 70 | yes | ✓ |
+| 11 | 4 | 3:50 | ATL | offensive holding | J. Matthews | 70 | yes | PENDING |
+| 12 | 4 | 0:57 | ATL | defensive offside | D. Freeney | 93 | yes | PENDING |
+| 13 | 5 (OT) | 11:18 | ATL | defensive pass interference | D. Campbell | 59 | yes | ✓ |
+
+All 4 audio-verified rows so far are **accepted** fouls. Per issue #60 review ask #2,
+the 3 **declined** fouls (rows 2, 3, 8) are kept in scope on the rule-based assumption
+that the referee announces the number regardless of the ensuing penalty decision — that
+assumption is not yet independently confirmed by transcription for these specific three,
+and is called out here rather than left implicit.
+
+## Announcement-class enumeration (issue #60 review ask #1)
+Cross-checked the Game Book-derived penalty list above against nflpenalties.com's
+independent penalty log for this game — the two sources agree on all 16 flags (13
+scored + 3 excluded below), which is a second, independent confirmation of the scope
+table beyond the original Game Book parse.
+
+| class | count this game | jersey number announced? | on-screen graphic | OCR-shortcut risk |
+|---|---|---|---|---|
+| player foul (accepted or declined) | 13 | yes (audio only, per SPEC evidence) | type + team banner only | none — number never appears on screen |
+| team foul (delay of game, illegal formation, illegal touching) | 3 | no | type + team banner only | n/a — correctly excluded, no number to leak or guess |
+| replay review | ≥1 (Q4, Falcons challenge of the Edelman catch, upheld) | no — not a foul, no jersey number or infraction type in this schema | on-screen "under review" / ruling graphic | out of scope for this schema; would need new fields, not a drop-in addition |
+| measurement | none found | no | chain-gang graphic | none found this game |
+
+**Status: partial.** The player-foul and team-foul rows are corroborated by two
+independent sources (Game Book parse + nflpenalties.com) and match exactly. The replay
+row is from general web sources, not yet cross-checked against the Game Book or the
+broadcast directly, and no measurement was found in either source — both should be
+confirmed against the primary Game Book PDF before this table is treated as final.
+Reviews and measurements do not carry a jersey number in this game's broadcast, so
+adding them to reach the ≥20-event target from review ask #4 would either require
+inapplicable/nullable fields on every row or dilute the audio/video seam the task is
+built around (they're visible on-screen, no audio-only component) — see the response to
+issue #60 for the scope/scoring recommendation.
 
 ## Exclusions (documented, per maintainer guidance in issue #60)
 These Game Book penalties are **not scored** because the referee's announcement does not
@@ -44,11 +86,19 @@ carry a player jersey number, by rule/convention:
 | 3 | 0:04 | ATL | delay of game | M. Bosher | 5 | team foul — no player number |
 
 ## Open design questions (for the PR / issue #60)
-- **Declined fouls (rows 2, 3, 8):** included here because the referee announces the number.
-  If the maintainer prefers accepted-only, dropping them yields 10 events.
-- **Event count:** 13 (vs 22 in the NBA worked example). The maintainer suggested widening to
-  *every* referee announcement including replay reviews and measurements; those carry no jersey
-  number and would need a schema addition, so they are left as a further extension pending
-  agreement rather than silently included.
-- **Clock precision:** clocks are the official Game Book values; the scorer allows ±5 s. Three
-  were additionally confirmed against the on-screen score bug by frame extraction.
+- **Declined fouls (rows 2, 3, 8):** included because the scope rule says the referee
+  announces the number regardless of the penalty decision. That assumption is verified
+  by transcription for 0 of these 3 rows so far (see the audio-verified column above) —
+  still open until confirmed the same way the 4 accepted rows were.
+- **Event count:** 13 natural events (16 total referee-mic penalty announcements, minus
+  3 with no jersey number). Reaching the ≥20 figure from review ask #4 would require
+  adding replay reviews and/or measurements, but this game has at most 1 review and no
+  measurements (see enumeration table above), and neither carries a jersey number or an
+  audio-only component — padding with them would dilute the audio/video seam rather than
+  extend it. Recommendation: keep the ~13-event scope and address the F1 fragility
+  (review ask #4's "single lucky guess clears 0.10" concern) as a scoring-shape question
+  instead of an event-count question.
+- **Clock precision:** superseded by the observable clock rule above (per review ask #5)
+  — clocks are the official Game Book values, scorer tolerance ±5 s, 3 of 13 rows
+  spot-checked against the score bug by frame extraction; full per-row audit against the
+  rule is open.

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/SPEC.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/SPEC.md
@@ -1,0 +1,76 @@
+---
+title: Spec Card — Super Bowl LI referee-announced player-foul timeline
+summary: Reconstruct every referee-announced player foul (quarter, clock, type, jersey number, team) from the full broadcast.
+read_when: Reviewing this task.
+---
+
+# Spec Card
+
+```yaml
+task: agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline
+
+# 1. What kind of thinking does this task need?
+cognitive_level: understanding   # relate a spoken announcement to an on-screen clock, across a long game
+
+# 2. Which modalities are REQUIRED (not just present)?
+modalities_required:
+  video: the game clock exists only in the on-screen score bug; the referee never states it.
+  audio: the penalised player's jersey number is stated only by the referee's microphone;
+         it appears in no on-screen graphic (verified by frame inspection).
+
+# 3. The exact question and output schema.
+question: Reconstruct every referee-announced player foul in Super Bowl LI.
+output_schema: >
+  {"penalties":[{"quarter":int(1-5), "clock":"mm:ss", "type":<closed vocab>,
+  "player_number":int, "team":"NE"|"ATL"}]}; clock tolerance 5 s; compound exact match.
+
+# 4. Evidence chain: far-apart moments in different modalities.
+evidence:
+  - "t~5190s (Q3 1:30), audio: referee 'holding, number 70, offense' -> #70 / offensive holding"
+  - "t~2500s (Q2 5:16), video: score bug shows the quarter and clock for that foul"
+  - "t~8420s (OT 11:18), audio+video: PI 'against number 59' + OT clock on the bug"
+
+# 5. Ground truth: value, source, tier, verification.
+ground_truth:
+  source: NFL official Game Book (nflgsis.com) penalty summary + roster for jersey numbers.
+  tier: machine-truth
+  verification: >
+    cross-checked against nflpenalties.com (13 accepted penalties, 88 yards, 16 flags).
+    Four announced jersey numbers independently verified by transcribing the broadcast
+    audio: #70 Matthews (Q3), #23 Alford (Q2), #34 Poole (Q2), #59 Campbell (OT PI).
+
+# 6. Scorer: deterministic code only.
+scorer:
+  metric: F1 over fouls; a TP requires type + jersey number + team + quarter, and clock within 5 s.
+  oracle_reward: 1.0            # verified locally (pilot subset)
+  null_reward: 0.0             # verified locally
+
+# 7. Difficulty: MEASURED with a real strong-agent run.
+difficulty:
+  strong_agent_reward: PENDING   # requires GPT 5.6 Sol calibration (not yet run)
+  tool_call_turns: PENDING
+  agent_model: PENDING
+
+# 8. Anti-shortcut ablations.
+anti_shortcut:
+  single_frame: PENDING
+  video_only: PENDING   # type+team+clock OCR-able, but jersey number is not -> compound match should stay near 0
+  audio_only: PENDING   # number+type audible, but no game clock -> cannot place a foul
+  no_media: 0.0        # indicative proxy run: a no-media no-tools model recalled 0/13 penalties
+  frame_dump_no_tools: PENDING
+
+# 9. Input media.
+input:
+  url: https://archive.org/download/youtube-noLK78Hgq0A/noLK78Hgq0A.mp4
+  sha256: ba2281d6293b3ee6a180decd508bb871de581841e6ea183ac17455c0344ba998   # verified, pinned in Dockerfile
+  length_min: 143
+  resolution: 1080      # verified: 1920x1080 by ffprobe/frame extraction
+```
+
+## Status
+
+This card is filled for the parts that are **verified locally** and marked `PENDING`
+where they require the maintainer's calibration stack (GPT 5.6 Sol) or steps not yet
+run. The pilot uses a 4-foul subset (the audio-verified fouls); the full-game ground
+truth — every referee announcement, per maintainer guidance in issue #60 — replaces it,
+in lockstep between `judge.py` GROUND_TRUTH and the oracle, before calibration.

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/SPEC.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/SPEC.md
@@ -33,15 +33,23 @@ evidence:
 # 5. Ground truth: value, source, tier, verification.
 ground_truth:
   source: NFL official Game Book (nflgsis.com) penalty summary + roster for jersey numbers.
-  tier: machine-truth
+  tier: official-record-derived, cross-checked by a broadcast audio/video audit (per
+        issue #60 review) -- not pure machine-truth, since the number-per-row audibility
+        and clock-per-row frame audit are load-bearing, not just a records lookup.
   verification: >
     cross-checked against nflpenalties.com (13 accepted penalties, 88 yards, 16 flags).
     Four announced jersey numbers independently verified by transcribing the broadcast
     audio: #70 Matthews (Q3), #23 Alford (Q2), #34 Poole (Q2), #59 Campbell (OT PI).
+    Full 13-row observability audit (audio timestamp+transcript vs. score-bug frame vs.
+    Game Book clock) is PENDING -- see PROVENANCE.md.
 
 # 6. Scorer: deterministic code only.
 scorer:
-  metric: F1 over fouls; a TP requires type + jersey number + team + quarter, and clock within 5 s.
+  metric: F-beta (beta=2, recall-weighted) over fouls; a TP requires type + jersey number
+          + team + quarter, and clock within 5 s. Chosen over F1 per issue #60 review --
+          F1 let one lucky exact row (0.1429) clear the 0.10 anti-shortcut gate; F2 does
+          not (0.0943). Regression-checked: null=0.0, one-hit=0.0943, two-hit=0.1852,
+          oracle=1.0 (steps/solve/tests/test_regressions.py).
   oracle_reward: 1.0            # verified locally (pilot subset)
   null_reward: 0.0             # verified locally
 

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/SPEC.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/SPEC.md
@@ -56,7 +56,9 @@ anti_shortcut:
   single_frame: PENDING
   video_only: PENDING   # type+team+clock OCR-able, but jersey number is not -> compound match should stay near 0
   audio_only: PENDING   # number+type audible, but no game clock -> cannot place a foul
-  no_media: 0.0        # indicative proxy run: a no-media no-tools model recalled 0/13 penalties
+  no_media: PENDING    # indicative proxy run (proxy model, pre-fix prompt) scored 0/13; must
+                        # be rerun on the FINAL prompt with the named strong model before this
+                        # counts as cleared
   frame_dump_no_tools: PENDING
 
 # 9. Input media.

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/SPEC.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/SPEC.md
@@ -70,7 +70,10 @@ input:
 ## Status
 
 This card is filled for the parts that are **verified locally** and marked `PENDING`
-where they require the maintainer's calibration stack (GPT 5.6 Sol) or steps not yet
-run. The pilot uses a 4-foul subset (the audio-verified fouls); the full-game ground
-truth — every referee announcement, per maintainer guidance in issue #60 — replaces it,
-in lockstep between `judge.py` GROUND_TRUTH and the oracle, before calibration.
+where they require the maintainer's calibration stack (GPT 5.6 Sol) or steps not yet run.
+
+**Ground truth is complete:** 13 referee-announced player fouls parsed from the official
+NFL Game Book, jersey numbers from the Game Book lineups, kept in lockstep between
+`judge.py` GROUND_TRUTH and the oracle `solve.sh`. Scope rule + 3 documented exclusions
+in `PROVENANCE.md`. Still `PENDING`: the three-agent calibration (GPT 5.6 Sol) and the
+media ablation runs, which require the agent/Harbor stack.

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/calibration/scores.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/calibration/scores.md
@@ -6,7 +6,7 @@ tool-call turns**. Oracle must be 1.0 and an empty attempt 0.
 
 | run | score | rollout (tool-call turns) |
 |---|---|---|
-| oracle (pilot subset) | 1.0 | — |
+| oracle (full 13-foul ground truth) | 1.0 | — |
 | empty / null | 0.0 | — |
 | plausible guess | 0.0 | — |
 | no_media (indicative proxy) | 0.0 | 0 |

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/calibration/scores.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/calibration/scores.md
@@ -8,8 +8,8 @@ tool-call turns**. Oracle must be 1.0 and an empty attempt 0.
 |---|---|---|
 | oracle (full 13-foul ground truth) | 1.0 | — |
 | empty / null | 0.0 | — |
-| plausible guess | 0.0 | — |
-| no_media (indicative proxy) | 0.0 | 0 |
+| plausible guess (pre-fix prompt) | 0.0 — stale, rerun pending | — |
+| no_media (indicative proxy, pre-fix prompt) | 0.0 — stale, rerun pending | 0 |
 | GPT 5.6 Sol | _to run_ | _to run_ |
 | Codex CLI | _to run_ | _to run_ |
 | Antigravity | _to run_ | _to run_ |
@@ -19,13 +19,19 @@ task structure (all required files), input video (143.1 min, **1080p**, confirme
 checker's ffprobe), oracle == 1.0, baseline == 0.0. The agent-reward, agent-turns, and
 ablation inputs are reported SKIP (they need the strong-agent stack).
 
-Status: PRE-CALIBRATION. Oracle / empty / no_media verified locally. The three-agent
-calibration (GPT 5.6 Sol first, per the README) has not been run — it requires the
-maintainer's agent stack and is the gating step before this task is PR-ready. Raw
-trajectories will be added under `rollouts/` once run.
+Status: PRE-CALIBRATION. Oracle / empty verified locally against the current prompt.
+`no_media` and `plausible guess` were run against the prompt **before** the leaked
+example rows in `instruction.md` were fixed (issue #60 review) — both must be rerun
+against the current prompt before being counted. The three-agent calibration (GPT 5.6
+Sol first, per the README) has not been run — it requires the maintainer's agent stack
+and is the gating step before this task is PR-ready. Raw trajectories will be added
+under `rollouts/` once run.
 
 Notes on what is already measured:
-- no_media: a strong model with no media and no tools reconstructed 0 of 13 accepted
-  penalties. Indicative (proxy model, not GPT 5.6 Sol), but de-risks the fame concern.
+- no_media (stale, pre-fix): a strong model with no media and no tools reconstructed 0
+  of 13 accepted penalties. Indicative (proxy model, not GPT 5.6 Sol); de-risks the fame
+  concern but needs rerunning on the fixed prompt with the named strong model.
 - audio intelligibility: the referee's announced jersey number transcribed cleanly on a
-  small CPU ASR model for 4/4 sampled player fouls (#70, #23, #34, #59).
+  small CPU ASR model for 4/4 sampled player fouls (#70, #23, #34, #59) — all 4 are
+  accepted fouls; the 3 declined fouls kept in scope are not yet audio-verified (see
+  PROVENANCE.md).

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/calibration/scores.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/calibration/scores.md
@@ -1,6 +1,8 @@
 # Calibration — ne-atl-2017-super-bowl-li-penalty-timeline
 
-Deterministic F1 scorer (`steps/solve/tests/judge.py`). A task clears the bar when
+Deterministic F2 (β=2, recall-weighted) scorer (`steps/solve/tests/judge.py`; switched
+from F1 per issue #60 review — F1 let one lucky exact row clear the 0.10 gate at
+0.1429, F2 does not at 0.0943). A task clears the bar when
 **every real agent scores below 0.10** and a real attempt takes **more than 50
 tool-call turns**. Oracle must be 1.0 and an empty attempt 0.
 

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/calibration/scores.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/calibration/scores.md
@@ -1,0 +1,26 @@
+# Calibration — ne-atl-2017-super-bowl-li-penalty-timeline
+
+Deterministic F1 scorer (`steps/solve/tests/judge.py`). A task clears the bar when
+**every real agent scores below 0.10** and a real attempt takes **more than 50
+tool-call turns**. Oracle must be 1.0 and an empty attempt 0.
+
+| run | score | rollout (tool-call turns) |
+|---|---|---|
+| oracle (pilot subset) | 1.0 | — |
+| empty / null | 0.0 | — |
+| plausible guess | 0.0 | — |
+| no_media (indicative proxy) | 0.0 | 0 |
+| GPT 5.6 Sol | _to run_ | _to run_ |
+| Codex CLI | _to run_ | _to run_ |
+| Antigravity | _to run_ | _to run_ |
+
+Status: PRE-CALIBRATION. Oracle / empty / no_media verified locally. The three-agent
+calibration (GPT 5.6 Sol first, per the README) has not been run — it requires the
+maintainer's agent stack and is the gating step before this task is PR-ready. Raw
+trajectories will be added under `rollouts/` once run.
+
+Notes on what is already measured:
+- no_media: a strong model with no media and no tools reconstructed 0 of 13 accepted
+  penalties. Indicative (proxy model, not GPT 5.6 Sol), but de-risks the fame concern.
+- audio intelligibility: the referee's announced jersey number transcribed cleanly on a
+  small CPU ASR model for 4/4 sampled player fouls (#70, #23, #34, #59).

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/calibration/scores.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/calibration/scores.md
@@ -14,6 +14,11 @@ tool-call turns**. Oracle must be 1.0 and an empty attempt 0.
 | Codex CLI | _to run_ | _to run_ |
 | Antigravity | _to run_ | _to run_ |
 
+`scripts/understanding/check_task.py` — PASS on every check not requiring the agent run:
+task structure (all required files), input video (143.1 min, **1080p**, confirmed by the
+checker's ffprobe), oracle == 1.0, baseline == 0.0. The agent-reward, agent-turns, and
+ablation inputs are reported SKIP (they need the strong-agent stack).
+
 Status: PRE-CALIBRATION. Oracle / empty / no_media verified locally. The three-agent
 calibration (GPT 5.6 Sol first, per the README) has not been run — it requires the
 maintainer's agent stack and is the gating step before this task is PR-ready. Raw

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/environment/Dockerfile
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/environment/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# The agent uses ffmpeg/ffprobe to seek, sample frames, and extract audio. The grader
+# is pure stdlib (it only compares integers and strings), so it needs nothing extra.
+
+# Bake the full-game broadcast at build time, the same way the v1.0 families do, with a
+# pinned URL and a SHA256 verified at build. The file is a pre-existing archive.org
+# upload; it is pinned directly (pin, not re-host), matching the gsw-cle worked example.
+#
+# SHA256 computed by streaming the archive.org file through sha256sum (2026-07-25).
+ARG MATERIALS_URL=https://archive.org/download/youtube-noLK78Hgq0A/noLK78Hgq0A.mp4
+ARG MATERIALS_SHA256=ba2281d6293b3ee6a180decd508bb871de581841e6ea183ac17455c0344ba998
+RUN mkdir -p /baked \
+ && curl --fail --silent --show-error --location --retry 5 --retry-delay 3 \
+      "$MATERIALS_URL" -o /baked/game.mp4 \
+ && echo "${MATERIALS_SHA256}  /baked/game.mp4" | sha256sum -c - \
+ && test -s /baked/game.mp4
+
+WORKDIR /workspace
+RUN mkdir -p /workspace/materials /workspace/output /workspace/work

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/environment/Dockerfile
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/environment/Dockerfile
@@ -12,10 +12,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # trial has the same deterministic transcription tool regardless of allow_internet.
 RUN pip install --no-cache-dir faster-whisper==1.2.1
 
-# Pre-download and cache the model at build time so transcription works fully offline
-# at trial time too. small.en balances accuracy on short spoken numbers against a
+# Pre-download and cache the model at build time, pinned to an exact HF commit rather
+# than "small.en" -> whatever "main" resolves to -- the same reproducibility bar as the
+# video's SHA256 pin below. small.en balances accuracy on short spoken numbers against a
 # CPU-only, no-torch runtime (ctranslate2 backend).
-RUN python3 -c "from faster_whisper import WhisperModel; WhisperModel('small.en', device='cpu', compute_type='int8')"
+#
+# Cached twice while still online: once at the pinned commit (verifies the pin resolves,
+# fails the build if it ever doesn't), and once with no revision arg, which is how an
+# agent will naturally call WhisperModel('small.en', ...) and defaults to resolving
+# "main". Without the second call, HF_HUB_OFFLINE below breaks that plain call: it looks
+# for a local "main" ref, finds only the hash-keyed entry, and errors instead of falling
+# back to it (verified locally).
+ARG WHISPER_MODEL_REVISION=d1d751a5f8271d482d14ca55d9e2deeebbae577f
+RUN python3 -c "from faster_whisper import WhisperModel; WhisperModel('small.en', device='cpu', compute_type='int8', revision='${WHISPER_MODEL_REVISION}')" \
+ && python3 -c "from faster_whisper import WhisperModel; WhisperModel('small.en', device='cpu', compute_type='int8')"
+
+# Force every later load -- build or trial, however the agent invokes it -- onto that
+# pinned local cache with no network resolution. Without this, allow_internet=true means
+# a runtime call could still re-resolve "main" over the network, reopening the same
+# drift the pin above closes.
+ENV HF_HUB_OFFLINE=1
 
 # Bake the full-game broadcast at build time, the same way the v1.0 families do, with a
 # pinned URL and a SHA256 verified at build. The file is a pre-existing archive.org

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/environment/Dockerfile
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/environment/Dockerfile
@@ -7,6 +7,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # The agent uses ffmpeg/ffprobe to seek, sample frames, and extract audio. The grader
 # is pure stdlib (it only compares integers and strings), so it needs nothing extra.
 
+# The referee's jersey-number call is audio-only evidence (see PROVENANCE.md) -- bake a
+# pinned ASR path rather than rely on an agent installing its own at runtime, so every
+# trial has the same deterministic transcription tool regardless of allow_internet.
+RUN pip install --no-cache-dir faster-whisper==1.2.1
+
+# Pre-download and cache the model at build time so transcription works fully offline
+# at trial time too. small.en balances accuracy on short spoken numbers against a
+# CPU-only, no-torch runtime (ctranslate2 backend).
+RUN python3 -c "from faster_whisper import WhisperModel; WhisperModel('small.en', device='cpu', compute_type='int8')"
+
 # Bake the full-game broadcast at build time, the same way the v1.0 families do, with a
 # pinned URL and a SHA256 verified at build. The file is a pre-existing archive.org
 # upload; it is pinned directly (pin, not re-host), matching the gsw-cle worked example.

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/instruction.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/instruction.md
@@ -6,14 +6,15 @@ every **referee-announced player foul** in the game.
 
 A *referee-announced player foul* is a penalty for which the referee announces a
 specific player's jersey number over the field microphone (for example, "Holding,
-number 70, offense"). Team fouls that carry no announced jersey number — such as delay
+number [N], offense"). Team fouls that carry no announced jersey number — such as delay
 of game or illegal formation — are **not** part of this task; do not report them.
 
-For each foul, report the quarter, the game clock at the moment the foul occurred, the
-infraction type, the jersey number of the penalised player, and their team. Use any
-tools in the image (for example `ffmpeg` and `ffprobe`) to seek through, sample frames
-from, and extract audio from the video. The referee's announcement, the on-screen
-score-and-clock graphic, and the play action are your evidence.
+For each foul, report the quarter, the game clock (defined below), the infraction type,
+the jersey number of the penalised player, and their team. Use any tools in the image
+(for example `ffmpeg`/`ffprobe`, and `faster-whisper` for transcribing the referee's
+audio) to seek through, sample frames from, extract audio from, and transcribe the
+video. The referee's announcement, the on-screen score-and-clock graphic, and the play
+action are your evidence.
 
 ## What to submit
 

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/instruction.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/instruction.md
@@ -22,15 +22,20 @@ Write `/workspace/output/solution.json` in exactly this shape:
 ```json
 {
   "penalties": [
-    {"quarter": 3, "clock": "1:30", "type": "offensive holding", "player_number": 70, "team": "ATL"},
-    {"quarter": 2, "clock": "8:02", "type": "defensive holding", "player_number": 23, "team": "ATL"}
+    {"quarter": 1, "clock": "5:00", "type": "false start", "player_number": 99, "team": "NE"},
+    {"quarter": 4, "clock": "2:15", "type": "unnecessary roughness", "player_number": 50, "team": "ATL"}
   ]
 }
 ```
 
+(The two rows above are formatting examples only, not real fouls from this game.)
+
 - One entry per referee-announced player foul, in any order.
 - `quarter`: 1 to 4, or 5 for overtime.
-- `clock`: the game clock shown on the broadcast when the foul occurred, as `mm:ss`.
+- `clock`: the game clock shown in the on-screen score bug on the **last frame it is
+  displayed before the referee begins the foul announcement**. The score bug is hidden
+  during live action and restored between plays, so use that specific frame — not the
+  time when the play ended, the down-and-distance display, or any other moment.
 - `type`: the infraction, lower-case, from this closed vocabulary — `offensive holding`,
   `defensive holding`, `offensive pass interference`, `defensive pass interference`,
   `false start`, `defensive offside`, `illegal contact`, `illegal use of hands`,

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/instruction.md
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/instruction.md
@@ -1,0 +1,47 @@
+# Super Bowl LI — Penalty Timeline Reconstruction
+
+You are given one video at `/workspace/materials/game.mp4`: the full broadcast of
+Super Bowl LI (New England Patriots vs Atlanta Falcons). Reconstruct the timeline of
+every **referee-announced player foul** in the game.
+
+A *referee-announced player foul* is a penalty for which the referee announces a
+specific player's jersey number over the field microphone (for example, "Holding,
+number 70, offense"). Team fouls that carry no announced jersey number — such as delay
+of game or illegal formation — are **not** part of this task; do not report them.
+
+For each foul, report the quarter, the game clock at the moment the foul occurred, the
+infraction type, the jersey number of the penalised player, and their team. Use any
+tools in the image (for example `ffmpeg` and `ffprobe`) to seek through, sample frames
+from, and extract audio from the video. The referee's announcement, the on-screen
+score-and-clock graphic, and the play action are your evidence.
+
+## What to submit
+
+Write `/workspace/output/solution.json` in exactly this shape:
+
+```json
+{
+  "penalties": [
+    {"quarter": 3, "clock": "1:30", "type": "offensive holding", "player_number": 70, "team": "ATL"},
+    {"quarter": 2, "clock": "8:02", "type": "defensive holding", "player_number": 23, "team": "ATL"}
+  ]
+}
+```
+
+- One entry per referee-announced player foul, in any order.
+- `quarter`: 1 to 4, or 5 for overtime.
+- `clock`: the game clock shown on the broadcast when the foul occurred, as `mm:ss`.
+- `type`: the infraction, lower-case, from this closed vocabulary — `offensive holding`,
+  `defensive holding`, `offensive pass interference`, `defensive pass interference`,
+  `false start`, `defensive offside`, `illegal contact`, `illegal use of hands`,
+  `unnecessary roughness`, `roughing the passer`.
+- `player_number`: the jersey number announced by the referee, as an integer.
+- `team`: `NE` or `ATL`.
+
+## Rules
+
+- Stay inside this working directory. Do not read, write, or search outside it.
+- Do not look anything up online, and do not rely on memory of this game; find every
+  foul in the video.
+- Report only referee-announced player fouls, as defined above. Do not report team
+  fouls that carry no announced jersey number.

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/solution/solve.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Oracle: write the verified referee-announced player-foul timeline as solution.json.
+#
+# The reference answer is the official NFL Game Book penalty summary (cross-checked on
+# nflpenalties.com), restricted by the task's scope rule to fouls with an announced
+# jersey number. Like the Assembly/basketball oracles, this is the verified answer key,
+# not an echo of the input. The agent never sees this file.
+#
+# NOTE: this is the PILOT subset — the four fouls whose announced jersey numbers were
+# verified by transcribing the broadcast audio. The full-game oracle (every referee
+# announcement, per maintainer guidance) is pending an official Game Book parse and will
+# replace this list, in lockstep with GROUND_TRUTH in ../tests/judge.py, before calibration.
+set -euo pipefail
+
+mkdir -p /workspace/output
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+PENALTIES = [
+    {"quarter": 2, "clock": "8:02",  "type": "defensive holding",           "player_number": 23, "team": "ATL"},
+    {"quarter": 2, "clock": "5:16",  "type": "defensive holding",           "player_number": 34, "team": "ATL"},
+    {"quarter": 3, "clock": "1:30",  "type": "offensive holding",           "player_number": 70, "team": "ATL"},
+    {"quarter": 5, "clock": "11:18", "type": "defensive pass interference", "player_number": 59, "team": "ATL"},
+]
+
+Path("/workspace/output/solution.json").write_text(json.dumps({"penalties": PENALTIES}, indent=2))
+PY
+
+echo "oracle: wrote /workspace/output/solution.json (pilot subset: 4 fouls)"

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/solution/solve.sh
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/solution/solve.sh
@@ -6,10 +6,9 @@
 # jersey number. Like the Assembly/basketball oracles, this is the verified answer key,
 # not an echo of the input. The agent never sees this file.
 #
-# NOTE: this is the PILOT subset — the four fouls whose announced jersey numbers were
-# verified by transcribing the broadcast audio. The full-game oracle (every referee
-# announcement, per maintainer guidance) is pending an official Game Book parse and will
-# replace this list, in lockstep with GROUND_TRUTH in ../tests/judge.py, before calibration.
+# The list is the full set of referee-announced player fouls from the official NFL Game
+# Book, kept in lockstep with GROUND_TRUTH in ../tests/judge.py. Scope rule and exclusions
+# are documented in ../../../PROVENANCE.md.
 set -euo pipefail
 
 mkdir -p /workspace/output
@@ -19,13 +18,22 @@ import json
 from pathlib import Path
 
 PENALTIES = [
+    {"quarter": 1, "clock": "13:47", "type": "offensive holding",           "player_number": 55, "team": "ATL"},
+    {"quarter": 2, "clock": "14:19", "type": "offensive holding",           "player_number": 88, "team": "NE"},
+    {"quarter": 2, "clock": "8:55",  "type": "defensive pass interference", "player_number": 23, "team": "NE"},
     {"quarter": 2, "clock": "8:02",  "type": "defensive holding",           "player_number": 23, "team": "ATL"},
+    {"quarter": 2, "clock": "6:10",  "type": "defensive holding",           "player_number": 34, "team": "ATL"},
     {"quarter": 2, "clock": "5:16",  "type": "defensive holding",           "player_number": 34, "team": "ATL"},
+    {"quarter": 2, "clock": "0:18",  "type": "offensive holding",           "player_number": 88, "team": "NE"},
+    {"quarter": 3, "clock": "13:02", "type": "offensive pass interference", "player_number": 15, "team": "NE"},
+    {"quarter": 3, "clock": "8:43",  "type": "defensive pass interference", "player_number": 21, "team": "NE"},
     {"quarter": 3, "clock": "1:30",  "type": "offensive holding",           "player_number": 70, "team": "ATL"},
+    {"quarter": 4, "clock": "3:50",  "type": "offensive holding",           "player_number": 70, "team": "ATL"},
+    {"quarter": 4, "clock": "0:57",  "type": "defensive offside",           "player_number": 93, "team": "ATL"},
     {"quarter": 5, "clock": "11:18", "type": "defensive pass interference", "player_number": 59, "team": "ATL"},
 ]
 
 Path("/workspace/output/solution.json").write_text(json.dumps({"penalties": PENALTIES}, indent=2))
 PY
 
-echo "oracle: wrote /workspace/output/solution.json (pilot subset: 4 fouls)"
+echo "oracle: wrote /workspace/output/solution.json (13 referee-announced player fouls)"

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/tests/judge.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Grade a Super Bowl LI referee-announced player-foul timeline. Pure stdlib, deterministic.
+
+The agent lists every referee-announced player foul with quarter, game clock, infraction
+type, penalised player's jersey number, and team. A prediction is a true positive only
+when it FULLY reconstructs the foul: same type, same jersey number, same team, same
+quarter, and a game clock within CLOCK_TOL seconds. reward = F1, so misses and
+hallucinations both hurt.
+
+Why cross-modal: the jersey number is stated only by the referee's microphone (audio),
+and the game clock is shown only in the on-screen score bug (video). The infraction type
+and team leak to OCR from the broadcast's penalty banner and carry no difficulty; the
+compound match rests on number + clock, which live in different channels. Neither channel
+alone yields a true positive.
+
+Ground truth: the NFL official Game Book (nflgsis.com), cross-checked against
+nflpenalties.com. Team fouls with no announced jersey number (delay of game, illegal
+formation, etc.) are excluded by the task's scope rule.
+
+NOTE: GROUND_TRUTH below is the PILOT subset — the four fouls whose announced jersey
+numbers were verified by transcribing the broadcast audio. The full-game ground truth
+(every referee announcement, per the maintainer's guidance) is pending an official Game
+Book parse and will replace this list before calibration.
+"""
+import argparse
+import json
+import re
+from pathlib import Path
+
+CLOCK_TOL = 5  # seconds of game-clock tolerance
+
+# Closed vocabulary of scored infraction types (normalised form).
+VALID_TYPES = {
+    "offensive holding", "defensive holding", "offensive pass interference",
+    "defensive pass interference", "defensive offside", "false start",
+    "unnecessary roughness", "roughing the passer", "illegal use of hands",
+    "defensive holding", "illegal contact",
+}
+
+# --- PILOT ground truth: the 4 audio-verified fouls (see NOTE above). ---
+GROUND_TRUTH = [
+    {"quarter": 2, "clock": "8:02", "type": "defensive holding",           "player_number": 23, "team": "ATL"},
+    {"quarter": 2, "clock": "5:16", "type": "defensive holding",           "player_number": 34, "team": "ATL"},
+    {"quarter": 3, "clock": "1:30", "type": "offensive holding",           "player_number": 70, "team": "ATL"},
+    {"quarter": 5, "clock": "11:18","type": "defensive pass interference", "player_number": 59, "team": "ATL"},
+]
+
+
+def norm_type(s):
+    return re.sub(r"\s+", " ", str(s).strip().lower())
+
+
+def clock_secs(cv):
+    cv = str(cv).strip()
+    try:
+        if ":" in cv:
+            m, s = cv.split(":")
+            return int(m) * 60 + int(float(s))
+        return int(float(cv))
+    except (ValueError, AttributeError):
+        return None
+
+
+def as_int(v):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def matches(pred, gt):
+    if norm_type(pred.get("type", "")) != norm_type(gt["type"]):
+        return False
+    if as_int(pred.get("player_number")) != gt["player_number"]:
+        return False
+    if str(pred.get("team", "")).strip().upper() != gt["team"]:
+        return False
+    if as_int(pred.get("quarter")) != gt["quarter"]:
+        return False
+    ps = clock_secs(pred.get("clock"))
+    gs = clock_secs(gt["clock"])
+    if ps is None or gs is None or abs(ps - gs) > CLOCK_TOL:
+        return False
+    return True
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--solution", required=True, type=Path)
+    ap.add_argument("--reward-json", required=True, type=Path)
+    ap.add_argument("--reward-txt", required=True, type=Path)
+    args = ap.parse_args()
+
+    reason = "ok"
+    preds = []
+    try:
+        sol = json.loads(args.solution.read_text())
+        preds = sol.get("penalties", [])
+        if not isinstance(preds, list):
+            raise ValueError("penalties is not a list")
+    except Exception as exc:  # noqa: BLE001 - malformed output scores 0
+        reason, preds = f"unreadable solution.json: {exc}", []
+
+    used = [False] * len(GROUND_TRUTH)
+    tp = 0
+    for pr in preds:
+        if not isinstance(pr, dict):
+            continue
+        for i, gt in enumerate(GROUND_TRUTH):
+            if not used[i] and matches(pr, gt):
+                used[i] = True
+                tp += 1
+                break
+
+    n_pred, n_gt = len(preds), len(GROUND_TRUTH)
+    precision = tp / n_pred if n_pred else 0.0
+    recall = tp / n_gt if n_gt else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+
+    details = {
+        "reason": reason,
+        "n_ground_truth": n_gt,
+        "n_predicted": n_pred,
+        "true_positives": tp,
+        "precision": round(precision, 4),
+        "recall": round(recall, 4),
+        "f1": round(f1, 4),
+        "clock_tolerance_s": CLOCK_TOL,
+        "pilot_subset": True,
+    }
+    args.reward_json.parent.mkdir(parents=True, exist_ok=True)
+    args.reward_json.write_text(json.dumps({"reward": round(f1, 4), "details": details}, indent=2))
+    args.reward_txt.write_text(f"{round(f1, 4)}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/tests/judge.py
@@ -4,8 +4,10 @@
 The agent lists every referee-announced player foul with quarter, game clock, infraction
 type, penalised player's jersey number, and team. A prediction is a true positive only
 when it FULLY reconstructs the foul: same type, same jersey number, same team, same
-quarter, and a game clock within CLOCK_TOL seconds. reward = F1, so misses and
-hallucinations both hurt.
+quarter, and a game clock within CLOCK_TOL seconds. reward = F-beta with BETA=2
+(recall-weighted), so misses and hallucinations both hurt, but a single lucky true
+positive no longer clears the anti-shortcut gate the way it did under plain F1 (one
+exact row out of 13: F1 = 0.1429 > 0.10 gate, F2 = 0.0943 < 0.10 gate).
 
 Why cross-modal: the jersey number is stated only by the referee's microphone (audio),
 and the game clock is shown only in the on-screen score bug (video). The infraction type
@@ -31,6 +33,7 @@ import re
 from pathlib import Path
 
 CLOCK_TOL = 5  # seconds of game-clock tolerance
+BETA = 2  # F-beta weight: recall counted BETA^2x precision, per issue #60 review
 
 # Closed vocabulary of scored infraction types (normalised form).
 VALID_TYPES = {
@@ -129,7 +132,9 @@ def main():
     n_pred, n_gt = len(preds), len(GROUND_TRUTH)
     precision = tp / n_pred if n_pred else 0.0
     recall = tp / n_gt if n_gt else 0.0
-    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+    beta_sq = BETA * BETA
+    denom = beta_sq * precision + recall
+    f_beta = ((1 + beta_sq) * precision * recall / denom) if denom else 0.0
 
     details = {
         "reason": reason,
@@ -138,13 +143,14 @@ def main():
         "true_positives": tp,
         "precision": round(precision, 4),
         "recall": round(recall, 4),
-        "f1": round(f1, 4),
+        "beta": BETA,
+        "f_beta": round(f_beta, 4),
         "clock_tolerance_s": CLOCK_TOL,
         "ground_truth_source": "official NFL Game Book",
     }
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
-    args.reward_json.write_text(json.dumps({"reward": round(f1, 4), "details": details}, indent=2))
-    args.reward_txt.write_text(f"{round(f1, 4)}\n")
+    args.reward_json.write_text(json.dumps({"reward": round(f_beta, 4), "details": details}, indent=2))
+    args.reward_txt.write_text(f"{round(f_beta, 4)}\n")
 
 
 if __name__ == "__main__":

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/tests/judge.py
@@ -17,10 +17,13 @@ Ground truth: the NFL official Game Book (nflgsis.com), cross-checked against
 nflpenalties.com. Team fouls with no announced jersey number (delay of game, illegal
 formation, etc.) are excluded by the task's scope rule.
 
-NOTE: GROUND_TRUTH below is the PILOT subset — the four fouls whose announced jersey
-numbers were verified by transcribing the broadcast audio. The full-game ground truth
-(every referee announcement, per the maintainer's guidance) is pending an official Game
-Book parse and will replace this list before calibration.
+GROUND_TRUTH below is the full set of referee-announced player fouls, parsed from the
+official NFL Game Book play-by-play, with jersey numbers taken from the Game Book
+lineups/substitutions. Scope rule and the three documented exclusions (delay of game,
+illegal formation, illegal touching — announced without a player number) are recorded
+in PROVENANCE.md. Four of the numbers (#23 Alford, #34 Poole, #70 Matthews, #59
+Campbell) were independently confirmed by transcribing the broadcast audio; all match
+the official lineup.
 """
 import argparse
 import json
@@ -37,12 +40,23 @@ VALID_TYPES = {
     "defensive holding", "illegal contact",
 }
 
-# --- PILOT ground truth: the 4 audio-verified fouls (see NOTE above). ---
+# --- Full ground truth: referee-announced player fouls (official Game Book). ---
+# quarter 5 = overtime. Both "accepted" and "declined" fouls are included (the referee
+# announces the number either way); no-number fouls are excluded (see PROVENANCE.md).
 GROUND_TRUTH = [
-    {"quarter": 2, "clock": "8:02", "type": "defensive holding",           "player_number": 23, "team": "ATL"},
-    {"quarter": 2, "clock": "5:16", "type": "defensive holding",           "player_number": 34, "team": "ATL"},
-    {"quarter": 3, "clock": "1:30", "type": "offensive holding",           "player_number": 70, "team": "ATL"},
-    {"quarter": 5, "clock": "11:18","type": "defensive pass interference", "player_number": 59, "team": "ATL"},
+    {"quarter": 1, "clock": "13:47", "type": "offensive holding",           "player_number": 55, "team": "ATL"},  # Worrilow
+    {"quarter": 2, "clock": "14:19", "type": "offensive holding",           "player_number": 88, "team": "NE"},   # Bennett (declined)
+    {"quarter": 2, "clock": "8:55",  "type": "defensive pass interference", "player_number": 23, "team": "NE"},   # Chung (declined)
+    {"quarter": 2, "clock": "8:02",  "type": "defensive holding",           "player_number": 23, "team": "ATL"},  # Alford
+    {"quarter": 2, "clock": "6:10",  "type": "defensive holding",           "player_number": 34, "team": "ATL"},  # Poole
+    {"quarter": 2, "clock": "5:16",  "type": "defensive holding",           "player_number": 34, "team": "ATL"},  # Poole
+    {"quarter": 2, "clock": "0:18",  "type": "offensive holding",           "player_number": 88, "team": "NE"},   # Bennett
+    {"quarter": 3, "clock": "13:02", "type": "offensive pass interference", "player_number": 15, "team": "NE"},   # Hogan (declined)
+    {"quarter": 3, "clock": "8:43",  "type": "defensive pass interference", "player_number": 21, "team": "NE"},   # Butler
+    {"quarter": 3, "clock": "1:30",  "type": "offensive holding",           "player_number": 70, "team": "ATL"},  # Matthews
+    {"quarter": 4, "clock": "3:50",  "type": "offensive holding",           "player_number": 70, "team": "ATL"},  # Matthews
+    {"quarter": 4, "clock": "0:57",  "type": "defensive offside",           "player_number": 93, "team": "ATL"},  # Freeney
+    {"quarter": 5, "clock": "11:18", "type": "defensive pass interference", "player_number": 59, "team": "ATL"},  # Campbell
 ]
 
 
@@ -126,7 +140,7 @@ def main():
         "recall": round(recall, 4),
         "f1": round(f1, 4),
         "clock_tolerance_s": CLOCK_TOL,
-        "pilot_subset": True,
+        "ground_truth_source": "official NFL Game Book",
     }
     args.reward_json.parent.mkdir(parents=True, exist_ok=True)
     args.reward_json.write_text(json.dumps({"reward": round(f1, 4), "details": details}, indent=2))

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/tests/test.sh
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/tests/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Verifier entry point. Preserve the agent's output for the audit trail, then grade.
+set -euo pipefail
+
+mkdir -p /logs/verifier /logs/artifacts
+
+if [ -d /workspace/output ]; then
+    cp -a /workspace/output/. /logs/artifacts/ 2>/dev/null || true
+fi
+
+python3 /tests/judge.py \
+        --solution /workspace/output/solution.json \
+        --reward-json /logs/verifier/reward.json \
+        --reward-txt /logs/verifier/reward.txt

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/tests/test_regressions.py
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/tests/test_regressions.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Regression checks for judge.py's F-beta scorer. Run manually before submitting:
+
+    python3 steps/solve/tests/test_regressions.py
+
+Checks the four cases from the issue #60 review: an empty submission, one exact row,
+two exact rows, and the full oracle set all land at the specified F2 values.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+JUDGE = HERE / "judge.py"
+
+sys.path.insert(0, str(HERE))
+from judge import GROUND_TRUTH  # noqa: E402
+
+CASES = [
+    ("null", [], 0.0),
+    ("one_hit", [dict(GROUND_TRUTH[0])], 0.0943),
+    ("two_hit", [dict(GROUND_TRUTH[0]), dict(GROUND_TRUTH[1])], 0.1852),
+    ("oracle", [dict(g) for g in GROUND_TRUTH], 1.0),
+]
+
+
+def run(preds: list) -> float:
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        sol = td / "solution.json"
+        sol.write_text(json.dumps({"penalties": preds}))
+        reward_json = td / "reward.json"
+        subprocess.run(
+            [sys.executable, str(JUDGE),
+             "--solution", str(sol),
+             "--reward-json", str(reward_json),
+             "--reward-txt", str(td / "reward.txt")],
+            check=True,
+        )
+        return json.loads(reward_json.read_text())["reward"]
+
+
+def main() -> int:
+    failed = False
+    for name, preds, expected in CASES:
+        got = run(preds)
+        ok = abs(got - expected) < 1e-3
+        print(f"{'OK  ' if ok else 'FAIL'} {name}: got {got}, expected {expected}")
+        failed = failed or not ok
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/workdir/setup.sh
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/steps/solve/workdir/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Pre-agent stage: copy the pre-baked broadcast into the agent's workspace.
+set -euo pipefail
+
+mkdir -p /workspace/materials /workspace/output /workspace/work
+cp /baked/game.mp4 /workspace/materials/game.mp4
+
+mkdir -p /logs/artifacts
+ls -la /workspace/materials/ > /logs/artifacts/materials-listing.txt
+
+rm -- "$0"

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/task.toml
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/task.toml
@@ -17,8 +17,11 @@ cpus = 4
 memory_mb = 8192
 # A full ~2.5h broadcast is several GB; give the build and trial room.
 storage_mb = 16384
-# The clip is baked at build time and the answer is not online: keep this false.
-allow_internet = false
+# The clip is baked at build time, but the Game Book (the ground-truth source) is
+# public — a lookup would leak the answer, not "the offline video." Internet stays on;
+# the safeguard is the no-lookup instruction plus a raw-trajectory audit, not a network
+# block (per maintainer guidance in issue #60).
+allow_internet = true
 
 [[steps]]
 name = "solve"

--- a/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/task.toml
+++ b/tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/task.toml
@@ -1,0 +1,31 @@
+version = "1.0"
+
+[task]
+name = "agentic-vbench/ne-atl-2017-super-bowl-li-penalty-timeline"
+
+[metadata]
+difficulty = "hard"
+category = "video-understanding"
+tags = ["video-understanding", "sports-analytics", "american-football", "audio-visual", "event-timeline"]
+# Full broadcast, Super Bowl LI (NE vs ATL, 2017-02-05), from archive.org.
+# Ground truth: official NFL Game Book (nflgsis.com), cross-checked on nflpenalties.com.
+source = "archive.org: youtube-noLK78Hgq0A (Super Bowl LI full broadcast, 1080p, 2h23m)"
+
+[environment]
+build_timeout_sec = 2400.0
+cpus = 4
+memory_mb = 8192
+# A full ~2.5h broadcast is several GB; give the build and trial room.
+storage_mb = 16384
+# The clip is baked at build time and the answer is not online: keep this false.
+allow_internet = false
+
+[[steps]]
+name = "solve"
+
+[steps.agent]
+# A full game is long: give the agent real time to seek, watch, and tally.
+timeout_sec = 3600.0
+
+[steps.verifier]
+timeout_sec = 600.0


### PR DESCRIPTION
## Task: Super Bowl LI referee-announced player-foul timeline

Proposed and discussed in #60. Adds `tasks/agentic_vbench_understanding/ne-atl-2017-super-bowl-li-penalty-timeline/`.

**Opened for design/code review — NOT yet calibration-complete, so it should not be merged until the calibration lands.** Shared early per the proposal-first process, so the design, scorer, and ground truth can be reviewed before the (expensive) calibration stage.

### What the task is
Reconstruct every referee-announced player foul from the full Super Bowl LI broadcast: quarter, game clock, infraction type, penalised player's jersey number, team. Cross-modal by construction — the jersey number is stated only by the referee's mic (audio), the game clock only by the on-screen score bug (video); neither channel alone yields a true positive. Ground truth = official NFL Game Book (machine-truth). Media pinned from archive.org (pin, not re-host), matching the `gsw-cle` worked example.

### Verified so far (locally)
- **Media:** `youtube-noLK78Hgq0A.mp4`, 1920×1080, 2h23m; **SHA256 pinned** in the Dockerfile (`ba2281d6…4ba998`, computed by streaming the file).
- **Scorer (`judge.py`):** deterministic compound-match F1. Local pilot: **oracle → 1.0, empty → 0.0, plausible guess → 0.0**, partial (clock off 3 s) → 0.57. Clock tolerance and wrong-number rejection behave as designed.
- **`no_media` gate (maintainer's step 1):** indicative proxy run — a no-media, no-tools model reconstructed **0/13** penalties (F1 0.0). De-risks the fame concern; the official GPT 5.6 Sol run is still required.
- **Audio intelligibility (design's single point of failure):** the referee's announced jersey number transcribed cleanly on a small CPU ASR model for **4/4** sampled player fouls — No. 70 Matthews (Q3), No. 23 Alford (Q2), No. 34 Poole (Q2), No. 59 Campbell (OT PI).

### Now complete (update)
- **Full ground truth — DONE.** Replaced the 4-foul pilot with **13 referee-announced player fouls** parsed from the official NFL Game Book play-by-play; jersey numbers taken from the Game Book lineups (the 4 audio-verified numbers all match). `judge.py` GROUND_TRUTH and the oracle `solve.sh` are in lockstep — locally **oracle 13/13 → 1.0, empty → 0.0, partial → 0.83**. Scope rule + the 3 no-number exclusions (delay of game, illegal formation, illegal touching) documented in `PROVENANCE.md`, per @christine1729's guidance in #60.

- **`check_task.py` — PASSES (partial).** Ran the repo's own `scripts/understanding/check_task.py`: **PASS** on task structure, input video (**143.1 min, 1080p** — resolution now confirmed by its ffprobe, not assumed), oracle == 1.0, baseline == 0.0. The agent-reward / agent-turns / ablation inputs are reported **SKIP** (they need the strong-agent stack).

### Still pending (needs the agent/Harbor stack — same dependency as calibration)
- **Calibration.** GPT 5.6 Sol / Codex / Antigravity rollouts + performance table + raw trajectories under `calibration/`. `scores.md` marks these `_to run_`.
- **Ablations.** `single_frame`, `video_only`, `audio_only`, `frame_dump_no_tools` — each is a strong-agent run on degraded media, so it needs the same stack as calibration.

### Open design questions on the ground truth (see `PROVENANCE.md`)
- **Declined fouls** (3 of the 13) are included because the referee announces the number; accepted-only would give 10. Your call.
- **Event count** is 13 vs 22 in the NBA example; widening to replay reviews / measurements would need a schema addition, so it is left open rather than silently included.

### Review asks
1. Is the scope rule (referee-announced *player* fouls; team fouls excluded because their fields are OCR-recoverable) the right boundary?
2. With type + team conceded to OCR, is the compound-match-on-number+clock cross-modal argument sufficient, or do you want a stricter formulation?
3. Anything you'd want changed in the task layout / scorer before the calibration spend?

Closes #60 once calibration lands (not with this draft).
