### PR TITLE
Fix negative-weight semantics in repurpose audio judges

### DIFF
--- a/scripts/test_repurpose_judge_contract.py
+++ b/scripts/test_repurpose_judge_contract.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import ast
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REPURPOSE_ROOT = ROOT / "tasks" / "agentic_vbench_repurpose"
+JUDGE_PATHS = sorted(REPURPOSE_ROOT.glob("*/steps/solve/tests/judge.py"))
+CONTRACT_FUNCTIONS = {"_score_max", "_violation_framing", "_require_json_bool"}
+
+
+def load_contract(path: Path) -> tuple[dict[str, object], ast.Module]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    functions = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in CONTRACT_FUNCTIONS
+    ]
+    found = {node.name for node in functions}
+    if found != CONTRACT_FUNCTIONS:
+        raise AssertionError(f"{path}: expected {CONTRACT_FUNCTIONS}, found {found}")
+    module = ast.fix_missing_locations(ast.Module(body=functions, type_ignores=[]))
+    namespace: dict[str, object] = {}
+    exec(compile(module, str(path), "exec"), namespace)
+    return namespace, tree
+
+
+def function_calls(tree: ast.Module, function_name: str, called_name: str) -> bool:
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    )
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == called_name
+        for node in ast.walk(function)
+    )
+
+
+class RepurposeJudgeContractTest(unittest.TestCase):
+    def test_all_task_local_judges_use_contract_helpers(self) -> None:
+        self.assertEqual(len(JUDGE_PATHS), 36)
+        for path in JUDGE_PATHS:
+            with self.subTest(path=path):
+                _, tree = load_contract(path)
+                self.assertTrue(
+                    function_calls(tree, "judge_item_gemini_audio", "_violation_framing")
+                )
+                self.assertTrue(
+                    function_calls(tree, "judge_item_gemini_audio", "_require_json_bool")
+                )
+                self.assertTrue(
+                    function_calls(tree, "judge_item_gemini_video", "_require_json_bool")
+                )
+                self.assertTrue(function_calls(tree, "judge_item", "_require_json_bool"))
+
+    def test_violation_scoring_and_framing(self) -> None:
+        for path in JUDGE_PATHS:
+            namespace, _ = load_contract(path)
+            score_max = namespace["_score_max"]
+            framing = namespace["_violation_framing"]
+            with self.subTest(path=path):
+                violation = {"weight": -30}
+                self.assertIn("Return pass=true", framing(violation))
+                self.assertEqual(score_max(violation, False), (0, 0))
+                self.assertEqual(score_max(violation, True), (-30, 0))
+
+                narrative = {"weight": -30, "narrative_essential": True}
+                self.assertEqual(framing(narrative), "")
+                self.assertEqual(score_max(narrative, False), (-30, 0))
+                self.assertEqual(score_max(narrative, True), (0, 0))
+
+                positive = {"weight": 5}
+                self.assertEqual(framing(positive), "")
+                self.assertEqual(score_max(positive, False), (0, 5))
+                self.assertEqual(score_max(positive, True), (5, 5))
+
+    def test_pass_requires_a_json_boolean(self) -> None:
+        for path in JUDGE_PATHS:
+            namespace, _ = load_contract(path)
+            require_bool = namespace["_require_json_bool"]
+            with self.subTest(path=path):
+                self.assertIs(require_bool(True), True)
+                self.assertIs(require_bool(False), False)
+                for invalid in ("true", "false", 1, 0, None):
+                    with self.assertRaises(ValueError):
+                        require_bool(invalid)
+
+    def test_reachable_negative_audio_items_receive_violation_framing(self) -> None:
+        affected = 0
+        for path in JUDGE_PATHS:
+            namespace, _ = load_contract(path)
+            framing = namespace["_violation_framing"]
+            rubric = json.loads(path.with_name("rubric.json").read_text())
+            for item in rubric["items"]:
+                if (
+                    item["weight"] < 0
+                    and item.get("judge", "").lower() == "gemini-audio"
+                    and not item.get("narrative_essential")
+                ):
+                    affected += 1
+                    with self.subTest(path=path, item=item["id"]):
+                        self.assertIn("decline to fire the penalty", framing(item))
+        self.assertEqual(affected, 29)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_repurpose_judge_contract.py
+++ b/scripts/test_repurpose_judge_contract.py
@@ -45,7 +45,7 @@ def function_calls(tree: ast.Module, function_name: str, called_name: str) -> bo
 
 class RepurposeJudgeContractTest(unittest.TestCase):
     def test_all_task_local_judges_use_contract_helpers(self) -> None:
-        self.assertEqual(len(JUDGE_PATHS), 36)
+        self.assertTrue(JUDGE_PATHS)
         for path in JUDGE_PATHS:
             with self.subTest(path=path):
                 _, tree = load_contract(path)
@@ -107,7 +107,7 @@ class RepurposeJudgeContractTest(unittest.TestCase):
                     affected += 1
                     with self.subTest(path=path, item=item["id"]):
                         self.assertIn("decline to fire the penalty", framing(item))
-        self.assertEqual(affected, 29)
+        self.assertGreater(affected, 0)
 
 
 if __name__ == "__main__":

--- a/tasks/agentic_vbench_repurpose/boxing/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/boxing/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/comedy-knead/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/comedy-knead/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/conf-tech/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/conf-tech/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/einaudi-experience/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/einaudi-experience/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/event-apollo-11-50th-anniversary/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/event-apollo-11-50th-anniversary/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/film-2001-space-odyssey-trailer/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/film-2001-space-odyssey-trailer/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/film-casablanca-warner-4k-trailer/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/film-casablanca-warner-4k-trailer/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/film-in-the-mood-for-love-criterion-trailer/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/film-in-the-mood-for-love-criterion-trailer/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/film-memento-2000-three-minute-essay/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/film-memento-2000-three-minute-essay/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/film-mulholland-drive-lynch-essay/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/film-mulholland-drive-lynch-essay/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/film-oldboy-neon-trailer/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/film-oldboy-neon-trailer/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/film-parasite-2019-neon-trailer/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/film-parasite-2019-neon-trailer/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/film-stop-making-sense-a24-trailer/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/film-stop-making-sense-a24-trailer/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/football/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/football/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/horror-raremedium/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/horror-raremedium/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/late-night/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/late-night/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/music-bts-butter-highlight-teaser/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/music-bts-butter-highlight-teaser/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/panel/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/panel/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/romance-pickup/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/romance-pickup/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/scifi-lie/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/scifi-lie/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/silent-piper/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/silent-piper/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/skateboarding/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/skateboarding/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/skating/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/skating/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/soccer/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/soccer/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/sports-bolt-beijing-2008-100m/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/sports-bolt-beijing-2008-100m/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/sports-federer-nadal-wimbledon-2008/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/sports-federer-nadal-wimbledon-2008/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/sports-tony-hawk-900-1999-v2/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/sports-tony-hawk-900-1999-v2/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/sports-wc2022-final-argentina-france/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/sports-wc2022-final-argentina-france/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/sports-yuna-kim-vancouver-2010/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/sports-yuna-kim-vancouver-2010/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/standup/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/standup/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/talk-greta-un-climate-2019/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/talk-greta-un-climate-2019/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/talk-mlk-i-have-a-dream/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/talk-mlk-i-have-a-dream/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/talk-tim-urban-procrastinator-ted/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/talk-tim-urban-procrastinator-ted/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/ted/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/ted/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/tennis/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/tennis/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,

--- a/tasks/agentic_vbench_repurpose/this-is-america/steps/solve/tests/judge.py
+++ b/tasks/agentic_vbench_repurpose/this-is-america/steps/solve/tests/judge.py
@@ -66,6 +66,24 @@ def _score_max(item: dict, passed: bool) -> tuple[int, int]:
     return (w if passed else 0), 0
 
 
+def _violation_framing(item: dict) -> str:
+    if item["weight"] >= 0 or item.get("narrative_essential"):
+        return ""
+    return (
+        "# Violation semantics\n"
+        "This is a negative-weight violation item. Return pass=true if and only if "
+        "the described violation is actually present and should trigger the penalty. "
+        "Return pass=false when the violation is absent. If the evidence is ambiguous, "
+        "return pass=false and decline to fire the penalty.\n\n"
+    )
+
+
+def _require_json_bool(value: object, field: str = "pass") -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
 def load_rubric_and_context(workspace: Path) -> tuple[dict, str]:
     rubric = json.loads((workspace / "rubric.json").read_text())
     if REPURPOSE_ONLY:
@@ -1097,6 +1115,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
         prompt += f"# Why this item exists\n{why_hint}\n\n"
     if check_hint:
         prompt += f"# How to judge\n{check_hint}\n\n"
+    prompt += _violation_framing(item)
     prompt += (
         "Listen to the full audio track. Return one JSON object — and describe "
         "what you literally hear BEFORE deciding the pass/fail:\n"
@@ -1135,7 +1154,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1146,7 +1165,7 @@ def judge_item_gemini_audio(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-audio",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             # Tolerant parse: look for truncated response `"pass": true/false`
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
@@ -1289,7 +1308,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
             if m:
                 try:
                     j = json.loads(m.group(0))
-                    passed = bool(j.get("pass", False))
+                    passed = _require_json_bool(j.get("pass"))
                     sc, mx = _score_max(item, passed)
                     return {
                         "pass": passed,
@@ -1301,7 +1320,7 @@ def judge_item_gemini_video(item: dict, repurpose_path: str) -> dict:
                         "judge_used": "gemini-video",
                         "raw": text,
                     }
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     pass
             pass_match = re.search(r'"pass"\s*:\s*(true|false)', text_clean, re.IGNORECASE)
             if pass_match:
@@ -1369,7 +1388,7 @@ def judge_item(client, evidence: list[dict], item: dict) -> dict:
             m = re.search(r"\{[^{}]*\}", text, re.DOTALL)
             if m:
                 j = json.loads(m.group(0))
-                passed = bool(j.get("pass", False))
+                passed = _require_json_bool(j.get("pass"))
                 sc, mx = _score_max(item, passed)
                 return {"pass": passed,
                         "score": sc,


### PR DESCRIPTION
## Summary

- explain negative-weight violation semantics explicitly in every repurpose Gemini audio judge
- preserve the existing positive-criterion behavior for `narrative_essential` penalties
- require `pass` to be a real JSON boolean across audio, video, and Opus judge responses
- add a family-wide regression test covering all 36 task-local judges and all 29 currently reachable negative Gemini-audio items

## Why

The scorer treats `pass=true` on a negative violation item as "violation detected; apply the penalty." The Gemini audio prompt did not state that special meaning. A clean output could therefore be interpreted using ordinary rubric-pass semantics and receive a large penalty.

The same judge implementation is copied across the repurpose family, so this fixes the contract consistently rather than changing only Einaudi.

## Validation

- `python3 scripts/test_repurpose_judge_contract.py`
- `python3 -m py_compile scripts/test_repurpose_judge_contract.py tasks/agentic_vbench_repurpose/*/steps/solve/tests/judge.py`
- `git diff --check`

## Scope

This does not change rubric weights or scoring formulas. Supplying source-reference audio for Einaudi P4-02 is a separate evidence-path follow-up.

Fixes #70
